### PR TITLE
Persistent items

### DIFF
--- a/Characters/Character.gd
+++ b/Characters/Character.gd
@@ -223,7 +223,7 @@ func createEquipment():
 	pass
 
 func resetEquipment():
-	inventory.clearEquippedItems()
+	inventory.clearEquippedItemsKeepPersistent()
 	createEquipment()
 	updateNonBattleEffects()
 

--- a/Game/BaseCharacter.gd
+++ b/Game/BaseCharacter.gd
@@ -2498,7 +2498,10 @@ func onSexStarted(_contex = {}):
 			continue
 		var effect = statusEffects[effectID]
 		effect.onSexStarted(_contex)
-
+	var items = getInventory().getItemsAndEquippedItemsTogether()
+	for item in items:
+		item.onSexStarted(_contex)
+	
 func processSexTurnContex(_contex = {}):
 	processSexTurn() # Legacy
 	
@@ -2516,6 +2519,9 @@ func onSexEnded(_contex = {}):
 			continue
 		var effect = statusEffects[effectID]
 		effect.onSexEnded(_contex)
-
+	var items = getInventory().getItemsAndEquippedItemsTogether()
+	for item in items:
+		item.onSexEnded(_contex)
+		
 func getForcedObedienceLevel() -> float:
 	return buffsHolder.getCustom(BuffAttribute.ForcedObedience)

--- a/Game/BaseCharacter.gd
+++ b/Game/BaseCharacter.gd
@@ -2498,9 +2498,6 @@ func onSexStarted(_contex = {}):
 			continue
 		var effect = statusEffects[effectID]
 		effect.onSexStarted(_contex)
-	#var items = getInventory().getItemsAndEquippedItemsTogether()
-	#for item in items:
-	#	item.onSexStarted(_contex)
 	
 func processSexTurnContex(_contex = {}):
 	processSexTurn() # Legacy
@@ -2519,9 +2516,6 @@ func onSexEnded(_contex = {}):
 			continue
 		var effect = statusEffects[effectID]
 		effect.onSexEnded(_contex)
-	#var items = getInventory().getItemsAndEquippedItemsTogether()
-	#for item in items:
-	#	item.onSexEnded(_contex)
 		
 func getForcedObedienceLevel() -> float:
 	return buffsHolder.getCustom(BuffAttribute.ForcedObedience)

--- a/Game/BaseCharacter.gd
+++ b/Game/BaseCharacter.gd
@@ -2498,9 +2498,9 @@ func onSexStarted(_contex = {}):
 			continue
 		var effect = statusEffects[effectID]
 		effect.onSexStarted(_contex)
-	var items = getInventory().getItemsAndEquippedItemsTogether()
-	for item in items:
-		item.onSexStarted(_contex)
+	#var items = getInventory().getItemsAndEquippedItemsTogether()
+	#for item in items:
+	#	item.onSexStarted(_contex)
 	
 func processSexTurnContex(_contex = {}):
 	processSexTurn() # Legacy
@@ -2519,9 +2519,9 @@ func onSexEnded(_contex = {}):
 			continue
 		var effect = statusEffects[effectID]
 		effect.onSexEnded(_contex)
-	var items = getInventory().getItemsAndEquippedItemsTogether()
-	for item in items:
-		item.onSexEnded(_contex)
+	#var items = getInventory().getItemsAndEquippedItemsTogether()
+	#for item in items:
+	#	item.onSexEnded(_contex)
 		
 func getForcedObedienceLevel() -> float:
 	return buffsHolder.getCustom(BuffAttribute.ForcedObedience)

--- a/Game/SexEngine/SexEngine.gd
+++ b/Game/SexEngine/SexEngine.gd
@@ -958,14 +958,15 @@ func endSex():
 			var item:ItemBase = character.getInventory().getItemByUniqueID(trackedItem[1])
 			if(item == null):
 				continue
-			character.getInventory().removeItem(item)
-			character.getInventory().removeEquippedItem(item)
-			var restraintData:RestraintData = item.getRestraintData()
-			if(restraintData != null):
-				restraintData.onStruggleRemoval()
+			if(!item.isPersistent()):
+				character.getInventory().removeItem(item)
+				character.getInventory().removeEquippedItem(item)
+				var restraintData:RestraintData = item.getRestraintData()
+				if(restraintData != null):
+					restraintData.onStruggleRemoval()
 			
-			GM.pc.getInventory().addItem(item)
-			GM.main.addMessage("You recovered "+item.getAStackName())
+				GM.pc.getInventory().addItem(item)
+				GM.main.addMessage("You recovered "+item.getAStackName())
 	trackedItems.erase("pc")
 	
 	for domID in doms:

--- a/Inventory/Inventory.gd
+++ b/Inventory/Inventory.gd
@@ -325,22 +325,38 @@ func removeEquippedItem(item):
 	return null
 
 func clear():
+	var persistentItems = []
+	var persistentEquipped = {}
 	for item in items:
-		item.currentInventory = null
+		if(item.isPersistent()):
+			persistentItems.append(item)
+		else:
+			item.currentInventory = null
 		#item.queue_free()
 	items.clear()
+	items = persistentItems
+	
 	
 	for itemSlot in equippedItems.keys():
 		#equippedItems[itemSlot].queue_free()
-		equippedItems[itemSlot].currentInventory = null
+		if(equippedItems[itemSlot].isPersistent()):
+			persistentEquipped[itemSlot] = equippedItems[itemSlot]
+		else:
+			equippedItems[itemSlot].currentInventory = null
 	equippedItems.clear()
+	equippedItems = persistentEquipped
 	emit_signal("equipped_items_changed")
 
 func clearEquippedItems():
+	var persistent = {}
 	for itemSlot in equippedItems.keys():
 		#equippedItems[itemSlot].queue_free()
-		equippedItems[itemSlot].currentInventory = null
+		if(equippedItems[itemSlot].isPersistent()):
+			persistent[itemSlot] = equippedItems[itemSlot]
+		else:
+			equippedItems[itemSlot].currentInventory = null
 	equippedItems.clear()
+	equippedItems = persistent
 	emit_signal("equipped_items_changed")
 
 func getEquippedItemsWithBuff(buffID):

--- a/Inventory/Inventory.gd
+++ b/Inventory/Inventory.gd
@@ -325,26 +325,16 @@ func removeEquippedItem(item):
 	return null
 
 func clear():
-	var persistentItems = []
-	var persistentEquipped = {}
 	for item in items:
-		if(item.isPersistent()):
-			persistentItems.append(item)
-		else:
-			item.currentInventory = null
+		item.currentInventory = null
 		#item.queue_free()
 	items.clear()
-	items = persistentItems
 	
 	
 	for itemSlot in equippedItems.keys():
 		#equippedItems[itemSlot].queue_free()
-		if(equippedItems[itemSlot].isPersistent()):
-			persistentEquipped[itemSlot] = equippedItems[itemSlot]
-		else:
-			equippedItems[itemSlot].currentInventory = null
+		equippedItems[itemSlot].currentInventory = null
 	equippedItems.clear()
-	equippedItems = persistentEquipped
 	emit_signal("equipped_items_changed")
 
 func clearEquippedItems():

--- a/Inventory/Inventory.gd
+++ b/Inventory/Inventory.gd
@@ -338,6 +338,13 @@ func clear():
 	emit_signal("equipped_items_changed")
 
 func clearEquippedItems():
+	for itemSlot in equippedItems.keys():
+		#equippedItems[itemSlot].queue_free()
+		equippedItems[itemSlot].currentInventory = null
+	equippedItems.clear()
+	emit_signal("equipped_items_changed")
+	
+func clearEquippedItemsKeepPersistent():
 	var persistent = {}
 	for itemSlot in equippedItems.keys():
 		#equippedItems[itemSlot].queue_free()

--- a/Inventory/ItemBase.gd
+++ b/Inventory/ItemBase.gd
@@ -468,6 +468,12 @@ func alwaysVisible():
 func shouldBeVisibleOnDoll(_character, _doll):
 	return true
 
+func onSexStarted(_contex = {}):
+	pass
+
+func onSexEnded(_contex = {}):
+	pass
+
 func onSexEnd():
 	pass
 

--- a/Inventory/ItemBase.gd
+++ b/Inventory/ItemBase.gd
@@ -468,12 +468,6 @@ func alwaysVisible():
 func shouldBeVisibleOnDoll(_character, _doll):
 	return true
 
-#func onSexStarted(_contex = {}):
-#	pass
-
-#func onSexEnded(_contex = {}):
-#	pass
-
 func onSexEnd():
 	pass
 

--- a/Inventory/ItemBase.gd
+++ b/Inventory/ItemBase.gd
@@ -468,11 +468,11 @@ func alwaysVisible():
 func shouldBeVisibleOnDoll(_character, _doll):
 	return true
 
-func onSexStarted(_contex = {}):
-	pass
+#func onSexStarted(_contex = {}):
+#	pass
 
-func onSexEnded(_contex = {}):
-	pass
+#func onSexEnded(_contex = {}):
+#	pass
 
 func onSexEnd():
 	pass

--- a/Inventory/ItemBase.gd
+++ b/Inventory/ItemBase.gd
@@ -523,3 +523,6 @@ func getInventoryImage():
 func onUnequipped():
 	if(itemState != null):
 		itemState.resetState()
+
+func isPersistent():
+	return false


### PR DESCRIPTION
This adds a function called `isPersistent` to `itemBase`, which is checked for in `sexEngine` and `inventory` to avoid returning persistent items to the player at the end of sex scenes and to avoid clearing them at the start of sex scenes.

It also adds `onSexStarted` and `onSexEnded` to `itemBase` and calls them at the same time as the similarly named functions for effects and the like in `baseCharacter`.

These changes should make it easier for item logic to be run at the start and end of sex scenes, and for items to be given to NPCs permanently, which is useful for the Portal Expansion Mod that I'm making.

Hopefully, there are no edge cases where this code causes something to break.