### PR TITLE
Fixes console/cout spam when deciding max value in getRoughLitterEstimateString

### DIFF
--- a/Game/Pregnancy/MenstrualCycle.gd
+++ b/Game/Pregnancy/MenstrualCycle.gd
@@ -307,7 +307,13 @@ func getRoughLitterEstimateString(veryAccurate = false):
 		disp = disp / 2
 	var minValue = RNG.randi_range(trueValue - int(disp * (1.0 - averageProgress)), trueValue)
 	minValue = Util.maxi(0, minValue)
-	var maxValue = RNG.randi_range(trueValue + int(disp * (1.0 - averageProgress)), trueValue)
+	var maxValueMin = trueValue + int(disp * (1.0 - averageProgress))
+	var maxValue = 0
+	if (maxValueMin > trueValue):
+		maxValue = RNG.randi_range(trueValue, maxValueMin)
+	else:
+		maxValue = RNG.randi_range(maxValueMin, trueValue)
+		
 
 	if(minValue == maxValue):
 		if(maxValue == 1):


### PR DESCRIPTION
This PR fixes console or cout print spam from RNG randi_range() that's bugging me on my playthrough.

Here is my issue, in my playthrough I noticed this strange spamming inside the console every time I walk around:
`randi_range() from is higher than to. From = 36 To = 34`
(36 is from calculation of then line 310 and 34 being trueValue)

I have tracked down the problem for me, I haven't test on other saves but it should work fine.

Here's the [save](https://files.catbox.moe/b3zd5w.save)
and you at least require [Hypertus](https://github.com/CanInBad/Hypertus) to load into the save then try walking around