### PR TITLE
Fixing targeted object in doSpitCumIntoHoleDom function

### DIFF
--- a/Game/SexEngine/SexActivityBase.gd
+++ b/Game/SexEngine/SexActivityBase.gd
@@ -756,7 +756,7 @@ func doCumBJFacialsSub(supposedToBeAngry = true):
 
 func doSpitCumIntoHoleDom(bodypartSlot = BodypartSlot.Vagina):
 	var mixtureText = getDom().getBodypartContentsStringList(BodypartSlot.Head)
-	var locationName:String = ("{dom.pussyStretch} "+RNG.pick(["pussy", "slit"]) if bodypartSlot == BodypartSlot.Vagina else ("{sub.anusStretch} "+RNG.pick(["anus"])))
+	var locationName:String = ("{sub.pussyStretch} "+RNG.pick(["pussy", "slit"]) if bodypartSlot == BodypartSlot.Vagina else ("{sub.anusStretch} "+RNG.pick(["anus"])))
 	var text = RNG.pick([
 		"{dom.You} {dom.youVerb('press')} {dom.yourHis} lips against {sub.yourHis} "+locationName+" and [b]{dom.youVerb('spit')} "+mixtureText+" into it[/b]!",
 	])


### PR DESCRIPTION
Seems like simple copy-paste error. Text refers to wrong person in the dialogue resulting in nasty ERROR:NO_VAGINA error on sex.

![2024-12-21_00-10](https://github.com/user-attachments/assets/3410ee91-e1e0-4da8-86a8-1e48e331b8bc)
