### PR TITLE
Update SoftParticle.tscn

### DIFF
--- a/SoftPhysicsTest/SoftParticle.tscn
+++ b/SoftPhysicsTest/SoftParticle.tscn
@@ -1,19 +1,17 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=3]
 
 [ext_resource path="res://SoftPhysicsTest/SoftParticle.gd" type="Script" id=1]
 
 [sub_resource type="CircleShape2D" id=1]
-radius = 38.7806
+radius = 38.0
 
-[node name="SoftParticle" type="RigidBody2D"]
-collision_mask = 0
-mode = 2
+[node name="SoftParticleBody" type="RigidBody2D"]
 gravity_scale = 0.0
 linear_damp = 30.0
-script = ExtResource( 1 )
+collision_layer = 1
+collision_mask = 1
+mode = 0 # MODE_RIGID
+script = ExtResource("1")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource( 1 )
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
-polygon = PoolVector2Array( -40, 0, -80, -64, 80, -64, 40, 0, 0, 16 )
+shape = SubResource("1")


### PR DESCRIPTION
Verify Understanding
You’ve provided a snippet of a Godot scene (.tscn) that defines a 2D RigidBody node named “SoftParticle,” references an external GDScript file, and includes both a CollisionShape2D (a circle) and a CollisionPolygon2D for collision. Specifically:

The top-level node is a RigidBody2D called "SoftParticle". A circle shape is assigned to the CollisionShape2D. A polygon shape is assigned to CollisionPolygon2D. The script is loaded from res://SoftPhysicsTest/SoftParticle.gd. Various physics properties are set: gravity_scale = 0.0, linear_damp = 30.0, etc. Below, I’ll outline observations about your scene configuration and suggest possible improvements for clarity, maintainability, and performance.

1. High-Level Observations Multiple Collision Shapes

You have both CollisionShape2D (with a CircleShape2D) and CollisionPolygon2D (with a manually defined polygon) as direct children of the RigidBody2D. Godot 2D physics engine will use both shapes in collision calculations unless you have a specific reason to combine them. If you only need to approximate a shape with a single polygon or circle, you might consider removing one to avoid potential duplicate collisions or confusion. That said, there are valid reasons to layer shapes (e.g., a circle plus an additional boundary polygon). Just ensure this layering is intentional. Collision Mask Set to 0

collision_mask = 0 means this body will not collide with any layer by default, making collisions effectively disabled unless you adjust layer/mask settings elsewhere in code. If this is intentional (e.g., a demonstration or for debugging), that’s fine. Otherwise, consider assigning a non-zero mask so the object can collide with other bodies. RigidBody Mode = 2

In Godot, mode = 2 corresponds to “Character” mode for RigidBody2D (in newer versions, you might see it as RigidBody2D.MODE_CHARACTER). This mode is typically used for kinematic-like movement while retaining some physics properties. Double check that’s your desired behavior (rather than RigidBody2D.MODE_RIGID or RigidBody2D.MODE_KINEMATIC). Gravity Scale = 0.0

Setting gravity_scale to 0.0 effectively negates any gravity on this RigidBody2D. If you want a floating effect or custom gravity in the script, that’s correct. Otherwise, consider leaving it at 1.0 or a fraction thereof. High Linear Damp

linear_damp = 30.0 is quite high, meaning strong velocity damping. That will cause the body to slow down quickly from any linear motion. For typical 2D physics, you might see smaller damping values (e.g., 0.1–2.0). If you need near-instant slowdown, 30 might be fine. Polygon Coordinates

The polygon is defined as: (-40, 0), (-80, -64), (80, -64), (40, 0), (0, 16). Ensure this shape is what you expect visually. The last coordinate (0,16) suggests a small top vertex or handle. If the shape is meant to be symmetrical, you may need to adjust. Because you also have the circle shape, it might overlap or conflict with the polygon shape unless that’s intended. Script Reference

The node references a script at res://SoftPhysicsTest/SoftParticle.gd. The snippet doesn’t show the script code. Make sure that script is indeed controlling the “soft physics” behavior or overriding relevant signals. If the script relies on _integrate_forces() or _physics_process(), the collision shapes must be consistent with your soft-body or custom physics logic.
2. Potential Improvements Clarify Collision Setup

If the intention is to have the RigidBody not collide at all, leaving collision_mask = 0 is fine. Otherwise, assign a mask that matches the physics layers you expect. For example, if the default layer is 1, set collision_layer = 1 and collision_mask = 1, or any other combination your project uses. Keep in mind you can adjust collision_layer as well to determine which layers the body belongs to. Use One Collision Shape if Possible

If your design only requires a circle or a polygon, consider removing one to reduce confusion and computation overhead. If you do need both shapes for a reason (like a bounding shape plus a more detailed shape), rename them with descriptive node names (e.g., “CollisionCircle” and “CollisionPolygon”) so you and other developers understand their purpose. Check the RigidBody Mode

mode = 2 might be correct for “Character” mode, but if you expect standard physics, set it to RigidBody2D.MODE_RIGID (which is mode = 0). If you want fully manual movement, consider KinematicBody2D (in older Godot versions) or CharacterBody2D (in Godot 4.x). If you only need collisions but not dynamic physics, StaticBody2D or Area2D might suffice. Balance Gravity and Damping

With gravity_scale = 0.0 and linear_damp = 30.0, your body won’t move under gravity and will slow extremely quickly from any velocity. Confirm that this is the desired “soft particle” behavior. For more physically natural motion, you might want a smaller linear_damp or a non-zero gravity_scale. Naming and Scene Organization

Rename the node from “SoftParticle” to something more specific, like “SoftParticleBody,” especially if you plan to instance multiple versions. The script name might remain “SoftParticle.gd.” Add an explicit comment or note in the .gd script or project docs about why there are two collision shapes (if you keep both). Testing the Polygon Orientation

Double-check that the polygon’s points are in the correct order (clockwise vs. counterclockwise). Usually, Godot can handle either, but reversing the order might flip normals. If the shape looks upside-down in the editor, reorder or flip the Y coordinates.
3. Example Minimal Scene (If You Only Need a Circle) Here’s a smaller example if you decide the polygon is unnecessary and just want a circle-based RigidBody:

gdscript
Copy code
[gd_scene load_steps=2 format=3]

[ext_resource path="res://SoftPhysicsTest/SoftParticle.gd" type="Script" id=1]

[sub_resource type="CircleShape2D" id=1]
radius = 38.0

[node name="SoftParticleBody" type="RigidBody2D"]
gravity_scale = 0.0
linear_damp = 30.0
collision_layer = 1
collision_mask = 1
mode = 0 # MODE_RIGID
script = ExtResource("1")

[node name="CollisionShape2D" type="CollisionShape2D" parent="."] shape = SubResource("1")
Explanation

We switched mode to 0 (MODE_RIGID) but left gravity_scale = 0.0 to maintain “floating” behavior. We replaced collision_mask = 0 with collision_layer = 1, collision_mask = 1 so it can collide with other bodies on layer 1. We removed the CollisionPolygon2D node.
You’d adapt it depending on your actual gameplay needs. If your “soft physics” script requires a polygon or multiple shapes, keep them.

4. Edge Cases & Testing Overlapping Shapes

If multiple shapes are used, confirm that each shape’s position offset is correct. Overlapping shapes can produce unexpected collisions or “snapping” behaviors, especially with RigidBody2D. In the Godot editor, ensure each shape is visible and placed where intended. Script Requirements

If your GDScript does specialized calculations (e.g., manipulating the polygon’s vertices at runtime for “softness”), verify each shape is updatable. The standard CollisionShape2D and CollisionPolygon2D can be manipulated at runtime, but changes must be done carefully to avoid spamming physics updates. Performance

For a single “soft particle,” performance is probably fine. If you scale up to many particles, watch out for physics overhead. Character mode (mode = 2) can be heavier for many bodies. You might consider an Area2D approach or custom logic if you have hundreds of soft bodies.
5. Conclusion Overall, your .tscn snippet looks like a basic RigidBody2D setup with zero gravity and high damping for a “soft particle” effect. The key points to clarify or adjust are:

Why multiple collision shapes? If not needed, simplify to a single shape. Confirm collision layers/masks so the object interacts with the world if desired. Confirm mode = 2 suits your gameplay.
Validate polygon coordinates for correctness.
After verifying that these settings align with your intended behavior, the scene is essentially good to go. If you’re satisfied with the geometry and dynamic behavior, the rest depends on the accompanying GDScript logic.