### PR TITLE
Added new option for adjusting block catcher panel size

### DIFF
--- a/Game/Datapacks/UI/CrotchCode/VisualSlots/BlockCatcherPanelSmall.gd
+++ b/Game/Datapacks/UI/CrotchCode/VisualSlots/BlockCatcherPanelSmall.gd
@@ -12,6 +12,6 @@ func drop_data(_position, _data):
 	emit_signal("onBlockDraggedOnto", _data, dropIndex)
 
 func _ready():
+	rect_min_size.y = OPTIONS.getBlockCatcherPanelHeight()
 	#var _ok = GlobalSignals.connect("onDragEnded", self, "onDragEnded")
 	#var _ok2 = GlobalSignals.connect("onDragStarted", self, "onDragStarted")
-	pass

--- a/Game/Datapacks/UI/CrotchCode/VisualSlots/BlockCatcherPanelSmall.tscn
+++ b/Game/Datapacks/UI/CrotchCode/VisualSlots/BlockCatcherPanelSmall.tscn
@@ -4,10 +4,6 @@
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0.145098 )
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
 corner_radius_top_left = 1
 corner_radius_top_right = 1
 corner_radius_bottom_right = 1

--- a/Game/Datapacks/UI/CrotchCode/VisualSlots/BlockCatcherPanelSmall.tscn
+++ b/Game/Datapacks/UI/CrotchCode/VisualSlots/BlockCatcherPanelSmall.tscn
@@ -4,6 +4,10 @@
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0.145098 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
 corner_radius_top_left = 1
 corner_radius_top_right = 1
 corner_radius_bottom_right = 1
@@ -13,7 +17,7 @@ anti_aliasing = false
 [node name="BlockCatcherPanelSmall" type="Panel"]
 anchor_right = 1.0
 margin_bottom = 1.0
-rect_min_size = Vector2( 0, 4 )
+rect_min_size = Vector2( 0, 16 )
 size_flags_horizontal = 3
 custom_styles/panel = SubResource( 1 )
 script = ExtResource( 1 )

--- a/Game/Options/GlobalOptions.gd
+++ b/Game/Options/GlobalOptions.gd
@@ -28,7 +28,7 @@ var smartLockRarity: String = "normal" # never veryrare rare normal often veryof
 var overstimulationEnabled: bool = true
 
 # Datapack editor
-var blockCatcherPanelHeight: int = 16
+var blockCatcherPanelHeight: int = 8
 
 var shouldScaleUI: bool = true
 var uiScaleMultiplier = 1.0
@@ -118,7 +118,7 @@ func resetToDefaults():
 	sandboxPawnCount = 30
 	sandboxBreeding = "rare"
 	sandboxNpcLeveling = 1.0
-	blockCatcherPanelHeight = 16
+	blockCatcherPanelHeight = 8
 	
 	enabledContent.clear()
 	for contentType in ContentType.getAll():

--- a/Game/Options/GlobalOptions.gd
+++ b/Game/Options/GlobalOptions.gd
@@ -27,6 +27,9 @@ var hardStruggleEnabled: bool = false
 var smartLockRarity: String = "normal" # never veryrare rare normal often veryoften bdsmslut always
 var overstimulationEnabled: bool = true
 
+# Datapack editor
+var blockCatcherPanelHeight: int = 16
+
 var shouldScaleUI: bool = true
 var uiScaleMultiplier = 1.0
 var requireDoubleTapOnMobile = false
@@ -115,6 +118,7 @@ func resetToDefaults():
 	sandboxPawnCount = 30
 	sandboxBreeding = "rare"
 	sandboxNpcLeveling = 1.0
+	blockCatcherPanelHeight = 16
 	
 	enabledContent.clear()
 	for contentType in ContentType.getAll():
@@ -263,6 +267,9 @@ func getCumShotsDependOnBallsVolume():
 func getCumShotsIntensityMult():
 	return cumIntensityMult
 
+func getBlockCatcherPanelHeight():
+	return blockCatcherPanelHeight
+
 func getSandboxPawnCount() -> int:
 	return sandboxPawnCount
 
@@ -306,6 +313,25 @@ func getChangeableOptions():
 					"value": showModdedLauncher,
 				},
 			],
+		},
+		{
+			"name": "Datapack",
+			"id": "datapack",
+			"options": [
+				{
+					"name": "Block catcher panel height",
+					"description": "Adjust the size(height) of the block catcher panel",
+					"id": "blockCatcherPanelHeight",
+					"type": "list",
+					"value": blockCatcherPanelHeight,
+					"values": [
+						[4, "4p"],
+						[8, "8p"],
+						[16, "16p"],
+						[32, "32p"],
+					]
+				}
+			]
 		},
 		{
 			"name": "Sandbox",
@@ -902,6 +928,10 @@ func applyOption(categoryID, optionID, value):
 			if(showModdedLauncher):
 				var _ok = OS.request_permissions()
 	
+	if(categoryID == "datapack"):
+		if(optionID == "blockCatcherPanelHeight"):
+			blockCatcherPanelHeight = value
+	
 	if(categoryID == "pregnancy"):
 		if(optionID == "menstrualCycleLengthDays"):
 			menstrualCycleLengthDays = value
@@ -1057,6 +1087,7 @@ func saveData():
 		"sandboxPawnCount": sandboxPawnCount,
 		"sandboxBreeding": sandboxBreeding,
 		"sandboxNpcLeveling": sandboxNpcLeveling,
+		"blockCatcherPanelHeight": blockCatcherPanelHeight,
 	}
 	
 	return data
@@ -1111,6 +1142,7 @@ func loadData(data):
 	sandboxPawnCount = loadVar(data, "sandboxPawnCount", 30)
 	sandboxBreeding = loadVar(data, "sandboxBreeding", "rare")
 	sandboxNpcLeveling = loadVar(data, "sandboxNpcLeveling", 1.0)
+	blockCatcherPanelHeight = loadVar(data, "blockCatcherPanelHeight", 16)
 
 func saveToFile():
 	var saveData = saveData()


### PR DESCRIPTION
I just recently discovered this thing existed and had no idea you could drag code blocks above others, it wasn't intuitive at all and mobile users had it rough, so i changed the default size of the node and made the size a setting, also added a very thin outline to highlight it