### PR TITLE
Add support for a portable data directory.

### DIFF
--- a/Game/GM.gd
+++ b/Game/GM.gd
@@ -13,9 +13,25 @@ func _init():
 	GES = GameExtenderSystem.new()
 
 func _ready():
-	var directory = Directory.new( )
+	var directory = Directory.new()
+
+	var exe_dir = OS.get_executable_path().get_base_dir()
+	print("Current Dir:", exe_dir)
+	var portable_dir = exe_dir.plus_file("BDCC.data")
+
+	if Directory.new().dir_exists(portable_dir):
+		print("Using portable save directory:", portable_dir)
+
+		if not Directory.new().dir_exists(portable_dir + "/Godot/app_userdata/BDCC"):
+			Directory.new().make_dir_recursive(portable_dir + "/Godot/app_userdata/BDCC")
+		
+		if OS.has_environment("APPDATA"):
+			OS.set_environment("APPDATA", portable_dir)  # Windows
+		if OS.has_environment("HOME"):
+			OS.set_environment("HOME", portable_dir)  # Linux & Mac
+		
 	directory.make_dir("user://saves")
 	directory.make_dir("user://mods")
 	directory.make_dir("user://custom_skins")
 	directory.make_dir("user://datapacks")
-	
+


### PR DESCRIPTION
A feature I have wanted for a hot bit, but basically just, 

if the user has created a `BDCC.data` folder along side the exe, it force sets the `%APPDATA%` environment variable to that folder instead of where it usually is, which results in all save data being stored there, rather than in the account files. 

If I knew how to make a global variable that everything could reference, I would adjust all uses of `user://` to use one, but this is my first time touching godot beyond poking it with a 5ft stick