### PR TITLE
Fix orifices becoming loose seemingly quicker than intended

### DIFF
--- a/Game/SexEngine/SexActivity/DomOralSexOnSub.gd
+++ b/Game/SexEngine/SexActivity/DomOralSexOnSub.gd
@@ -458,7 +458,7 @@ func doDomAction(_id, _actionInfo):
 		var text = RNG.pick([
 			"{dom.You} {dom.youVerb('open')} {dom.yourHis} mouth and {dom.youVerb('let')} {sub.your} "+RNG.pick(["cock", "dick", "member"])+" in before wrapping {dom.yourHis} lips around it.",
 		])
-		getDom().gotOrificeStretchedBy(BodypartSlot.Head, subID, 0.1)
+		getDom().gotOrificeStretchedBy(BodypartSlot.Head, subID, true, 0.1)
 		affectSub(subInfo.fetishScore({Fetish.OralSexReceiving: 1.0}), 0.1, -0.3, -0.01)
 		sendSexEvent(SexEvent.HolePenetrated, subID, domID, {hole=BodypartSlot.Head,engulfed=true,strapon=false})
 		return {text = text, domSay=domReaction(SexReaction.AboutToSuckSubOff)}

--- a/Game/SexEngine/SexActivity/DomRidingSubVaginal.gd
+++ b/Game/SexEngine/SexActivity/DomRidingSubVaginal.gd
@@ -288,7 +288,7 @@ func processTurn():
 			sendSexEvent(SexEvent.PainInflicted, subID, domID, {pain=howMuchPainAdd,isDefense=false,intentional=false})
 			subInfo.addLust(10)
 			subInfo.addArousalForeplay(0.1)
-			getDom().gotOrificeStretchedBy(usedBodypart, subID, 0.1)
+			getDom().gotOrificeStretchedBy(usedBodypart, subID, true, 0.1)
 			return combineData({text = text}, processExtra())
 	
 	if(state == "fucking"):
@@ -307,7 +307,7 @@ func processTurn():
 		if(RNG.chance(20)):
 			var freeRoom = getDom().getPenetrationFreeRoomBy(usedBodypart, subID)
 			
-			getDom().gotOrificeStretchedBy(usedBodypart, subID, 0.1)
+			getDom().gotOrificeStretchedBy(usedBodypart, subID, true, 0.1)
 			
 			if(usedBodypart == BodypartSlot.Vagina):
 				if(freeRoom <= 5.0):
@@ -597,7 +597,7 @@ func doDomAction(_id, _actionInfo):
 		#var isTryingToKnot = false
 		if(_id == "letsubknotinside"):
 			#isTryingToKnot = true
-			getDom().gotOrificeStretchedBy(usedBodypart, subID, 0.5)
+			getDom().gotOrificeStretchedBy(usedBodypart, subID, true, 0.5)
 			if(RNG.chance(getDom().getKnottingChanceBy(usedBodypart, subID))):
 				knotSuccess = true
 			else:
@@ -723,7 +723,7 @@ func doDomAction(_id, _actionInfo):
 			var text = RNG.pick([
 				"{dom.You} {dom.youVerb('try', 'tries')} to "+RNG.pick(["pull", "yank"])+" {sub.yourHis} "+RNG.pick(["cock", "dick"])+" out but {dom.youVerb('fail')}. The knot inside {dom.youHim} slowly deflates.",
 			])
-			getDom().gotOrificeStretchedBy(usedBodypart, subID, 0.1)
+			getDom().gotOrificeStretchedBy(usedBodypart, subID, true, 0.1)
 			affectSub(subInfo.fetishScore({fetishGiving: 1.0}), 0.1, -0.3, 0.0)
 			affectDom(domInfo.fetishScore({fetishReceiving: 1.0}), 0.1, -0.05)
 			subInfo.addArousalForeplay(0.1)
@@ -738,7 +738,7 @@ func doDomAction(_id, _actionInfo):
 		return {text = "{dom.You} {dom.youVerb('rub')} {dom.yourHis} "+RNG.pick(usedBodypartNames)+" against {sub.yourHis} "+getDickName()+".",}
 	if(_id == "envelop"):
 		if(!RNG.chance(getDom().getPenetrateChanceBy(usedBodypart, subID))):
-			getDom().gotOrificeStretchedBy(usedBodypart, subID, 0.1)
+			getDom().gotOrificeStretchedBy(usedBodypart, subID, true, 0.1)
 			affectSub(subInfo.fetishScore({fetishGiving: 1.0}), 0.1 * subSensetivity(), 0.0, 0.0)
 			affectDom(domInfo.fetishScore({fetishReceiving: 1.0}), 0.2, -0.01)
 			return {text="{dom.You} {dom.youVerb('try', 'tries')} to envelop {sub.yourHis} "+getDickName()+" but it's too big!"}
@@ -750,7 +750,7 @@ func doDomAction(_id, _actionInfo):
 		domInfo.stimulateArousalZone(0.1, usedBodypart, 0.5)
 		
 		#getSub().gotFuckedBy(usedBodypart, domID)
-		getDom().gotOrificeStretchedBy(usedBodypart, subID, 0.2)
+		getDom().gotOrificeStretchedBy(usedBodypart, subID, true, 0.2)
 		#gonnaCumOutside = false
 		state = "fucking"
 		return {text = "{dom.You} {dom.youVerb('envelop')} {sub.youHis} "+getDickName()+", letting it penetrate {dom.yourHis} "+RNG.pick(usedBodypartNames)+"."}
@@ -985,7 +985,7 @@ func inside_domActions():
 
 func inside_doDomAction(_id, _actionInfo):
 	if(_id == "ridemore"):
-		getDom().gotOrificeStretchedBy(usedBodypart, subID, 0.2)
+		getDom().gotOrificeStretchedBy(usedBodypart, subID, true, 0.2)
 		#gonnaCumOutside = false
 		state = "fucking"
 		return {text = "{dom.You} {dom.youVerb('continue')} to ride {sub.youHis} "+getDickName()+" with {dom.yourHis} "+RNG.pick(usedBodypartNames)+"."}

--- a/Game/SexEngine/SexActivity/SexOral.gd
+++ b/Game/SexEngine/SexActivity/SexOral.gd
@@ -353,7 +353,7 @@ func doDomAction(_id, _actionInfo):
 				"{dom.You} {dom.youVerb('try', 'tries')} to force {dom.yourHis} "+getDickName()+" deeper but {sub.yourHis} throat is just too tight.",
 				"{dom.You} {dom.youVerb('try', 'tries')} to make {sub.you} deepthroat {dom.yourHis} "+getDickName()+" but {sub.youHe} {sub.youAre} just too tight.",
 				])
-			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, 0.1)
+			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, true, 0.1)
 			affectSub(domInfo.fetishScore({Fetish.OralSexGiving: 1.0}), 0.1, -0.1, -0.05)
 			domInfo.addLust(0.1)
 			domInfo.addArousalSex(0.03)
@@ -367,7 +367,7 @@ func doDomAction(_id, _actionInfo):
 				text = RNG.pick([
 					"{dom.You} {dom.youVerb('reach', 'reaches')} for {sub.yourHis} horns and use them as handlebars. ",
 				]) + text
-			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, 0.2)
+			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, true, 0.2)
 			affectSub(domInfo.fetishScore({Fetish.OralSexGiving: 1.0}), 0.1, -0.2, -0.05)
 			domInfo.addArousalSex(0.05 * domSensitivity())
 			return {text=text}
@@ -684,7 +684,7 @@ func doSubAction(_id, _actionInfo):
 			var text = RNG.pick([
 				"{sub.You} {sub.youVerb('try', 'tries')} to get {dom.yourHis} "+getDickName()+" into {sub.yourHis} throat but "+RNG.pick(["it's too big", "{sub.youHe} {sub.youVerb('struggle')}", "{sub.youVerb('fail')}"])+".",
 			])
-			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, 0.1)
+			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, true, 0.1)
 			affectDom(domInfo.fetishScore({Fetish.OralSexReceiving: 1.0}), 0.2*domSensitivity(), -0.03)
 			return {text = text}
 		else:
@@ -692,7 +692,7 @@ func doSubAction(_id, _actionInfo):
 			var text = RNG.pick([
 				"{sub.You} willingly {sub.youVerb('let')} {dom.yourHis} "+getDickName()+" deep down {sub.yourHis} throat and {sub.youVerb('start')} deepthroating it!",
 			])
-			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, 0.2)
+			getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, true, 0.2)
 			affectDom(domInfo.fetishScore({Fetish.OralSexReceiving: 1.0}), 0.2*domSensitivity(), -0.03)
 			domInfo.addArousalForeplay(0.05*domSensitivity())
 			return {text=text}

--- a/Game/SexEngine/SexActivity/SexVaginalOnAllFours.gd
+++ b/Game/SexEngine/SexActivity/SexVaginalOnAllFours.gd
@@ -332,7 +332,7 @@ func processTurn():
 			sendSexEvent(SexEvent.PainInflicted, domID, subID, {pain=howMuchPainAdd,isDefense=false,intentional=false})
 			domInfo.addLust(10)
 			domInfo.addArousalForeplay(0.1)
-			getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.1)
+			getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.1)
 			return {text = text}
 	
 	if(state == "fucking"):
@@ -355,7 +355,7 @@ func processTurn():
 		if(RNG.chance(20)):
 			var freeRoom = getSub().getPenetrationFreeRoomBy(usedBodypart, domID)
 			
-			getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.1)
+			getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.1)
 			
 			if(usedBodypart == BodypartSlot.Vagina):
 				if(freeRoom <= 5.0):
@@ -616,7 +616,7 @@ func doDomAction(_id, _actionInfo):
 		else:
 			# Cock len vs Vagina depth check here
 			if(!RNG.chance(getSub().getPenetrateChanceBy(usedBodypart, domID))):
-				getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.1)
+				getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.1)
 				var text = RNG.pick([
 					"{dom.Your} "+getDickName()+" stretches {sub.your} "+RNG.pick(usedBodypartNames)+" out while trying to fit inside.",
 				])
@@ -630,7 +630,7 @@ func doDomAction(_id, _actionInfo):
 				sendSexEvent(SexEvent.HolePenetrated, domID, subID, {hole=usedBodypart,engulfed=false,strapon=isStraponSex()})
 				gonnaCumOutside = false
 				#getSub().gotFuckedBy(usedBodypart, domID)
-				getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.2)
+				getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.2)
 				state = "fucking"
 				affectSub(subInfo.fetishScore({fetishReceiving: 1.0}), 0.1, -0.3, 0.0)
 				affectDom(domInfo.fetishScore({fetishGiving: 1.0}), 0.1*domSensitivity(), -0.05)
@@ -684,7 +684,7 @@ func doDomAction(_id, _actionInfo):
 				getSub().doPainfullyStretchHole(usedBodypart, domID)
 			
 			#isTryingToKnot = true
-			getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.5)
+			getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.5)
 			if(RNG.chance(getSub().getKnottingChanceBy(usedBodypart, domID))):
 				knotSuccess = true
 			else:
@@ -820,7 +820,7 @@ func doDomAction(_id, _actionInfo):
 			var text = RNG.pick([
 				"{dom.You} {dom.youVerb('try', 'tries')} to "+RNG.pick(["pull", "yank"])+" {dom.yourHis} "+RNG.pick(["cock", "dick"])+" out but {dom.youVerb('fail')}. The knot slowly deflates.",
 			])
-			getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.1)
+			getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.1)
 			affectSub(subInfo.fetishScore({fetishReceiving: 1.0}), 0.1, -0.3, 0.0)
 			affectDom(domInfo.fetishScore({fetishGiving: 1.0}), 0.1, -0.05)
 			subInfo.addArousalForeplay(0.1)
@@ -952,7 +952,7 @@ func doSubAction(_id, _actionInfo):
 		return {text = "{sub.You} {sub.youVerb('rub')} against {dom.youHim}.",}
 	if(_id == "envelop"):
 		if(!RNG.chance(getSub().getPenetrateChanceBy(usedBodypart, domID))):
-			getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.1)
+			getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.1)
 			affectSub(subInfo.fetishScore({fetishReceiving: 1.0}), 0.1, 0.0, 0.0)
 			affectDom(domInfo.fetishScore({fetishGiving: 1.0}), 0.2, -0.01)
 			return {text="{sub.You} {sub.youVerb('try', 'tries')} to envelop {dom.yourHis} "+getDickName()+" but it's too big!"}
@@ -964,7 +964,7 @@ func doSubAction(_id, _actionInfo):
 		domInfo.stimulateArousalZone(0.1, BodypartSlot.Penis, 0.5)
 		
 		#getSub().gotFuckedBy(usedBodypart, domID)
-		getSub().gotOrificeStretchedBy(usedBodypart, domID, 0.2)
+		getSub().gotOrificeStretchedBy(usedBodypart, domID, true, 0.2)
 		gonnaCumOutside = false
 		state = "fucking"
 		return {text = "{sub.You} {sub.youVerb('engulf')} {dom.youHis} "+getDickName()+", letting it penetrate {sub.yourHis} "+RNG.pick(usedBodypartNames)+"."}

--- a/Game/SexEngine/SexActivityBase.gd
+++ b/Game/SexEngine/SexActivityBase.gd
@@ -826,7 +826,7 @@ func doBlowjobTurnDom():
 	affectDom(domInfo.fetishScore({Fetish.OralSexReceiving: 0.5})+0.6, 0.1*getDomPenisSensetivity(), 0.0)
 	subInfo.addArousalForeplay(0.03)
 	domInfo.stimulateArousalZone(0.2, BodypartSlot.Penis, 1.0)
-	getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, 0.05)
+	getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, true, 0.05)
 	
 	var text = RNG.pick([
 		"{dom.Your} "+getDomDickName()+" is being sucked by {sub.youHim}.",
@@ -891,7 +891,7 @@ func doBlowjobTurnDom():
 
 
 func doDeepthroatTurnDom():
-	getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, 0.1)
+	getSub().gotOrificeStretchedBy(BodypartSlot.Head, domID, true, 0.1)
 	affectSub(subInfo.fetishScore({Fetish.OralSexGiving: 1.0})-0.3, 0.1, -0.1, -0.01)
 	affectDom(domInfo.fetishScore({Fetish.OralSexReceiving: 0.5})+0.6, 0.1*getDomPenisSensetivity(), 0.0)
 	subInfo.addArousalForeplay(0.06)
@@ -1070,7 +1070,7 @@ func doBlowjobTurnSub():
 	affectDom(domInfo.fetishScore({Fetish.OralSexGiving: 0.5})+0.1, 0.1, 0.0)
 	domInfo.addArousalForeplay(0.03)
 	subInfo.stimulateArousalZone(0.2, BodypartSlot.Penis, 1.0)
-	getDom().gotOrificeStretchedBy(BodypartSlot.Head, subID, 0.05)
+	getDom().gotOrificeStretchedBy(BodypartSlot.Head, subID, true, 0.05)
 	
 	var text = RNG.pick([
 		"{dom.You} {dom.youAre} sucking {sub.your} "+RNG.pick(["cock", "dick", "member"])+".",


### PR DESCRIPTION
Each method call should now have a `showMessages` argument explicitly set to `true`, to shift the position of stretchMult float to the fourth position, in order to match the function definition:

https://github.com/Alexofp/BDCC/blob/110d9ce8e2d8d70d54b3fed19f543dd93d8108ee/Game/BaseCharacter.gd#L1073