### PR TITLE
Fix unlikely actions within interactions not being filtered out

### DIFF
--- a/Game/InteractionSystem/InteractionSystem.gd
+++ b/Game/InteractionSystem/InteractionSystem.gd
@@ -164,7 +164,7 @@ func decideNextAction(interaction, _context:Dictionary = {}):
 	for action in actions:
 		var newScore:float = interaction.calcFinalActionScore(action)
 		action["finalScore"] = newScore
-		if(maxScore > newScore):
+		if(newScore > maxScore):
 			maxScore = newScore
 	
 	var minScore:float = maxScore * 0.1 # Filtering out unlikely actions


### PR DESCRIPTION
Sometimes pawns will perform a "justleave" action with 1% probability, even if the threshold/cutout was intended to be set to 10%.