### PR TITLE
Add ability to refuse help with restraints, stocks and the slutwall

### DIFF
--- a/Game/BaseCharacter.gd
+++ b/Game/BaseCharacter.gd
@@ -3018,39 +3018,83 @@ func hasSomethingToStruggleOutOf() -> bool:
 		return true
 	return false
 
-func doStruggleOutOfRestraints(isScared:bool = false, addStats:bool = true, customActor=null, damageMult:float = 1.0) -> Dictionary:
+func getRestraintsToStruggleOutOf() -> Dictionary:
 	var possible = []
 	var trivial = []
-	
-	var whoStruggles = self
-	if(customActor != null):
-		whoStruggles = customActor
-	
+
 	for item in getInventory().getEquppedRestraints():
-		var restraintData: RestraintData = item.getRestraintData()
-		
+		var restraintData:RestraintData = item.getRestraintData()
+
 		if(restraintData == null || !restraintData.canStruggleFinal() || !restraintData.shouldStruggle()):
 			continue
-		
+
 		if(!restraintData.shouldDoStruggleMinigame(self)):
 			trivial.append(item)
 		else:
 			possible.append(item)
-	
-	var pickedItem
-	var minigameResult:MinigameResult
+
+	var restraintsToStruggleOutOf = {
+		possible = possible,
+		trivial = trivial,
+	}
+
+	return restraintsToStruggleOutOf
+
+func getNextRestraintToStruggleOutOf(deterministicOrderHashInt:int = 0):
+	var nextRestraintToStruggleOutOf = null
+
+	if(deterministicOrderHashInt == 0):
+		deterministicOrderHashInt = RNG.randi_range(1, 1000000)
+
+	var restraintsToStruggleOutOf:Dictionary = getRestraintsToStruggleOutOf()
+
+	var possible:Array = restraintsToStruggleOutOf.possible
+	var trivial:Array = restraintsToStruggleOutOf.trivial
+
+	for item in possible:
+		if(item.id in ["StocksStatic", "SlutwallStatic"]):
+			nextRestraintToStruggleOutOf = {
+				item = item,
+				isTrivial = false,
+			}
+			return nextRestraintToStruggleOutOf
+
 	if(trivial.size() > 0):
-		pickedItem = RNG.pick(trivial)
+		nextRestraintToStruggleOutOf = {
+			item = RNG.pickHashed(trivial, deterministicOrderHashInt),
+			isTrivial = true,
+		}
+		return nextRestraintToStruggleOutOf
+	elif(possible.size() > 0):
+		nextRestraintToStruggleOutOf = {
+			item = RNG.pickHashed(possible, deterministicOrderHashInt),
+			isTrivial = false,
+		}
+		return nextRestraintToStruggleOutOf
+	else:
+		nextRestraintToStruggleOutOf = null
+		return nextRestraintToStruggleOutOf
+
+func doStruggleOutOfRestraints(isScared:bool = false, addStats:bool = true, customActor=null, damageMult:float = 1.0, deterministicOrderHashInt:int = 0) -> Dictionary:
+	var nextRestraintToStruggleOutOf = getNextRestraintToStruggleOutOf(deterministicOrderHashInt)
+
+	if(nextRestraintToStruggleOutOf == null):
+		return {}
+
+	var whoStruggles = self
+	if(customActor != null):
+		whoStruggles = customActor
+
+	var pickedItem = nextRestraintToStruggleOutOf.item
+	var minigameResult:MinigameResult
+	if(nextRestraintToStruggleOutOf.isTrivial):
 		minigameResult = MinigameResult.new()
 		minigameResult.score = 1.0
-	elif(possible.size() > 0):
-		pickedItem = RNG.pick(possible)
+	else:
 		minigameResult = whoStruggles.getRestraintStrugglingMinigameResult()
-		
+
 		if(isScared):
 			minigameResult.score = min(minigameResult.score, min(1.0, RNG.randf_range(0.6, 1.1)))
-	else:
-		return {}
 	
 	if(customActor != null):
 		minigameResult.beingHelped = true

--- a/Game/InteractionSystem/Interactions/HelpingWithRestraints.gd
+++ b/Game/InteractionSystem/Interactions/HelpingWithRestraints.gd
@@ -1,10 +1,12 @@
 extends PawnInteractionBase
 
-var surrendered = false
-var struggleText = ""
-var tryCount = 0
-var askCredits = 0
-var reacterStarted = false
+var surrendered:bool = false
+var struggleText:String = ""
+var tryCount:int = 0
+var askCredits:int = 0
+var reacterStarted:bool = false
+var deterministicOrderHashInt:int = 0
+var restraintItemID:String = ""
 
 func _init():
 	id = "HelpingWithRestraints"
@@ -12,9 +14,10 @@ func _init():
 func start(_pawns:Dictionary, _args:Dictionary):
 	doInvolvePawn("starter", _pawns["starter"])
 	doInvolvePawn("reacter", _pawns["reacter"])
+	deterministicOrderHashInt = RNG.randi_range(1, 1000000)
 	if(_args.has("reacterStarted") && _args["reacterStarted"]):
 		reacterStarted = true
-		setState("restraints_agree", "reacter")
+		setState("init_eager_to_help", "starter")
 	else:
 		reacterStarted = false
 		setState("", "reacter")
@@ -39,13 +42,58 @@ func init_do(_id:String, _args:Dictionary, _context:Dictionary):
 		setState("restraints_deny", "starter")
 
 
+func init_eager_to_help_text():
+	if(struggleText != ""):
+		saynn(struggleText)
+
+	var restraintData = getRoleChar("starter").getNextRestraintToStruggleOutOf(deterministicOrderHashInt)
+	var restraintIsPlural = getRestraintIsPlural(restraintData.item) if(restraintData != null) else false
+	var restraintVisibleName = restraintData.item.getVisibleName() if(restraintData != null) else "the restraint"
+	saynn("{reacter.You} {reacter.youAre} about to help {starter.you} remove "+ restraintVisibleName + ".")
+
+	if(struggleText == ""):
+		sayLine("reacter", "HelpRestraintsAltStart", {main="reacter", target="starter"}, {restraintIsPlural=restraintIsPlural})
+
+	var acceptHelpProbability = getStarterAcceptHelpProbability()
+	var refuseHelpProbability = 1.0 - acceptHelpProbability
+	addAction("accept", "Accept", "Allow them to help with your restraints", "default", acceptHelpProbability, 60, {})
+	addAction("refuse", "Refuse", "You'd rather keep " + ("it" if(!restraintIsPlural) else "them"), "default", refuseHelpProbability, 60, {})
+
+func init_eager_to_help_do(_id:String, _args:Dictionary, _context:Dictionary):
+	if(_id == "accept"):
+		setState("restraints_agree", "reacter")
+	if(_id == "refuse"):
+		setState("eager_help_refused", "reacter")
+
+
+func eager_help_refused_text():
+	var restraintData = getRoleChar("starter").getNextRestraintToStruggleOutOf(deterministicOrderHashInt)
+	var restraintIsPlural = getRestraintIsPlural(restraintData.item) if(restraintData != null) else false
+	var restraintVisibleName = restraintData.item.getVisibleName() if(restraintData != null) else "the restraint"
+
+	saynn("{starter.You} {starter.youVerb('refuse', 'refused')} {reacter.your} help with removing "+restraintVisibleName+".")
+
+	var idSuffix = "Unhappy" if( RNG.chance(50) ) else "Kinky"
+	sayLine("starter", "HelpRestraintsAltRefuse"+idSuffix, {main="starter", target="reacter"}, {restraintIsPlural=restraintIsPlural})
+
+	if( (idSuffix == "Kinky") && RNG.chance(50) ):
+		sayLine("reacter", "HelpRestraintsAltRefuseKinkyReact", {main="reacter", target="starter"})
+
+	addAction("leave", "Leave", "Time to go", "default", 1.0, 60, {})
+
+func eager_help_refused_do(_id:String, _args:Dictionary, _context:Dictionary):
+	if(_id == "leave"):
+		getRolePawn("starter").afterSocialInteraction()
+		getRolePawn("reacter").satisfySocial()
+		stopMe()
+
+
 func restraints_agree_text():
 	if(!reacterStarted):
 		saynn("{reacter.name} nods and starts tugging on {starter.your} restraints.")
 		sayLine("reacter", "HelpRestraintsAgree", {main="reacter", target="starter"})
 	else:
-		saynn("{reacter.name} looks at {starter.your} restraints.")
-		sayLine("reacter", "HelpRestraintsAltStart", {main="reacter", target="starter"})
+		saynn("{reacter.name} starts tugging on {starter.your} restraints.")
 
 	addAction("help", "Help", "Start helping..", "default", 1.0, 60, {})
 
@@ -54,8 +102,6 @@ func restraints_agree_do(_id:String, _args:Dictionary, _context:Dictionary):
 		doHelpStruggleForStarter()
 		getRolePawn("reacter").afterSocialInteraction()
 		getRolePawn("starter").afterSocialInteraction()
-		setState("restraints_helping", "reacter")
-		tryCount = 1
 
 
 func restraints_deny_text():
@@ -83,8 +129,6 @@ func restraints_helping_text():
 func restraints_helping_do(_id:String, _args:Dictionary, _context:Dictionary):
 	if(_id == "help"):
 		doHelpStruggleForStarter()
-		setState("restraints_helping", "reacter")
-		tryCount += 1
 	if(_id == "stop"):
 		setState("restraints_enough", "starter")
 	if(_id == "stop_ask_credits"):
@@ -174,6 +218,8 @@ func restraints_refusedwhatever_do(_id:String, _args:Dictionary, _context:Dictio
 func getAnimData() -> Array:
 	if(getState() in ["restraints_refuse_attack", "reacter_won", "reacter_won_leave", "starter_won", "starter_won_leave"]):
 		return [StageScene.Duo, "stand", {pc="starter", npc="reacter"}]
+	if((getState() == "init_eager_to_help" && (tryCount == 0)) || getState() == "eager_help_refused"):
+		return [StageScene.Duo, "stand", {pc="reacter", npc="starter"}]
 	return [StageScene.SexStart, "start", {pc="reacter", npc="starter"}]
 	
 func getPreviewLineForRole(_role:String) -> String:
@@ -184,14 +230,38 @@ func getPreviewLineForRole(_role:String) -> String:
 	return .getPreviewLineForRole(_role)
 
 func doHelpStruggleForStarter():
+	var restraintData = getRoleChar("starter").getNextRestraintToStruggleOutOf(deterministicOrderHashInt)
+	restraintItemID = restraintData.item.id if(restraintData != null) else ""
+
 	var theStarter = getRoleChar("starter")
-	var struggleData:Dictionary = theStarter.doStruggleOutOfRestraints(false, true, getRoleChar("reacter"), 1.0)
+	var struggleData:Dictionary = theStarter.doStruggleOutOfRestraints(false, true, getRoleChar("reacter"), 1.0, deterministicOrderHashInt)
 	if(struggleData.empty()):
 		struggleText = "Something happened.."
 	else:
 		struggleText = struggleData["text"]
 		if(reacterStarted):
 			affectAffection("starter", "reacter", 0.02)
+
+	tryCount += 1
+
+	if(reacterStarted && !getRoleChar("starter").getInventory().hasItemIDEquipped(restraintItemID) && getRoleChar("starter").getInventory().hasRemovableRestraintsNoLockedSmartlocks() && getRoleChar("reacter").getStamina() > 0):
+		setState("init_eager_to_help", "starter")
+	else:
+		setState("restraints_helping", "reacter")
+
+func getStarterAcceptHelpProbability() -> float:
+	var acceptHelpProbability:float = 1.0
+
+	var starterDommyness:float = getRolePawn("starter").scorePersonalityMax({PersonalityStat.Subby: -1.0})
+	var saverDommyness:float = getRolePawn("reacter").scorePersonalityMax({PersonalityStat.Subby: -1.0})
+	var dommynessDisadvantageRatio:float = max(saverDommyness - starterDommyness, 0.0) / 2.0
+
+	acceptHelpProbability = clamp(1.0 - getRolePawn("starter").scoreFetishMax({ Fetish.Bondage: 0.8 }) + 0.6 * dommynessDisadvantageRatio, 0.0, 1.0)
+	return acceptHelpProbability
+
+func getRestraintIsPlural(item:ItemBase) -> bool:
+	# Ideally there'd be item.isPlural(), but the best we can do for now is an approximate guess
+	return ( item.getClothingSlot() in [InventorySlot.Wrists, InventorySlot.Hands, InventorySlot.Ankles] )
 
 func saveData():
 	var data = .saveData()
@@ -201,6 +271,8 @@ func saveData():
 	data["tryCount"] = tryCount
 	data["askCredits"] = askCredits
 	data["reacterStarted"] = reacterStarted
+	data["deterministicOrderHashInt"] = deterministicOrderHashInt
+	data["restraintItemID"] = restraintItemID
 	return data
 
 func loadData(_data):
@@ -211,4 +283,6 @@ func loadData(_data):
 	tryCount = SAVE.loadVar(_data, "tryCount", 0)
 	askCredits = SAVE.loadVar(_data, "askCredits", 0)
 	reacterStarted = SAVE.loadVar(_data, "reacterStarted", false)
+	deterministicOrderHashInt = SAVE.loadVar(_data, "deterministicOrderHashInt", 0)
+	restraintItemID = SAVE.loadVar(_data, "restraintItemID", "")
 

--- a/Game/InteractionSystem/Interactions/HelpingWithRestraints.gd
+++ b/Game/InteractionSystem/Interactions/HelpingWithRestraints.gd
@@ -256,7 +256,7 @@ func getStarterAcceptHelpProbability() -> float:
 	var saverDommyness:float = getRolePawn("reacter").scorePersonalityMax({PersonalityStat.Subby: -1.0})
 	var dommynessDisadvantageRatio:float = max(saverDommyness - starterDommyness, 0.0) / 2.0
 
-	acceptHelpProbability = clamp(1.0 - getRolePawn("starter").scoreFetishMax({ Fetish.Bondage: 0.8 }) + 0.6 * dommynessDisadvantageRatio, 0.0, 1.0)
+	acceptHelpProbability = clamp(1.0 - getRolePawn("starter").scoreFetishMax({ Fetish.Bondage: 0.60 }) + 0.45 * dommynessDisadvantageRatio, 0.0, 1.0)
 	return acceptHelpProbability
 
 func getRestraintIsPlural(item:ItemBase) -> bool:

--- a/Game/InteractionSystem/Interactions/InSlutwall.gd
+++ b/Game/InteractionSystem/Interactions/InSlutwall.gd
@@ -5,6 +5,8 @@ var savedHow = ""
 var saveTryCount = 0
 var useCount = 0
 var tips = 0
+var shoutedForHelpCount = 0
+var immediatelyLeft = false
 
 func _init():
 	id = "InSlutwall"
@@ -62,6 +64,7 @@ func init_do(_id:String, _args:Dictionary, _context:Dictionary):
 		checkSleep()
 		getCharByRole("inmate").addStamina(50)
 	if(_id == "shout"):
+		shoutedForHelpCount += 1
 		setState("about_to_shout", "inmate")
 	if(_id == "struggle"):
 		if(getRolePawn("inmate").isPlayer()):
@@ -174,7 +177,11 @@ func after_use_do(_id:String, _args:Dictionary, _context:Dictionary):
 
 
 func about_to_save_text():
-	saynn("{saver.name} approaches {inmate.you}!")
+	if(saveTryCount == 0):
+		saynn("{saver.You} {saver.youVerb('approach', 'approaches')} {inmate.you}!")
+	else:
+		saynn("{saver.You} {saver.youVerb('stand')} next to {inmate.you}.")
+
 	saynn("{saver.YouHe} can either spend some of {saver.yourHis} stamina and help {inmate.you} to struggle out of the slutwall.. or use a restraint key to unlock it.")
 
 	if(getRoleChar("saver").getStamina() > 0):
@@ -187,37 +194,72 @@ func about_to_save_text():
 
 func about_to_save_do(_id:String, _args:Dictionary, _context:Dictionary):
 	if(_id == "help"):
-		saveTryCount += 1
-		var inmate = getRoleChar("inmate")
-		var struggleData:Dictionary = inmate.doStruggleOutOfRestraints(false, true, getRoleChar("saver"), 2.0)
-		if(struggleData.empty()):
-			struggleText = "Something happened.."
+		if(saveTryCount == 0):
+			setState("refusable_save_using_stamina", "inmate")
 		else:
-			struggleText = struggleData["text"]
-		
-		if(inmate.getInventory().hasItemIDEquipped("SlutwallStatic")):
-			setState("save_after_help", "inmate")
-		else:
-			savedHow = "help"
-			setState("save_saved", "inmate")
-			affectAffection("inmate", "saver", 0.2)
+			saveUsingStamina()
 	if(_id == "key"):
-		savedHow = "key"
-		setState("save_saved", "inmate")
-		affectAffection("inmate", "saver", 0.2)
-		getRoleChar("saver").getInventory().removeXOfOrDestroy("restraintkey", 1)
-		getRoleChar("inmate").getInventory().clearStaticRestraints()
+		if(saveTryCount == 0):
+			setState("refusable_save_using_key", "inmate")
+		else:
+			saveUsingKey()
+	if(_id == "leave"):
+		if(saveTryCount == 0):
+			immediatelyLeft = true
+		setState("canceled_save", "saver")
+
+
+func refusable_save_using_stamina_text():
+	saynn("{saver.You} {saver.youAre} about to help {inmate.you} struggle out of the slutwall.")
+
+	var acceptHelpProbability = getInmateAcceptHelpProbability()
+	var refuseHelpProbability = 1.0 - acceptHelpProbability
+	addAction("accept", "Accept", "Allow them to help you", "default", acceptHelpProbability, 60, {})
+	addAction("refuse", "Refuse", "You'd rather stay in the slutwall", "default", refuseHelpProbability, 60, {})
+
+func refusable_save_using_stamina_do(_id:String, _args:Dictionary, _context:Dictionary):
+	if(_id == "accept"):
+		saveUsingStamina()
+	if(_id == "refuse"):
+		setState("refused_save", "saver")
+
+
+func refusable_save_using_key_text():
+	saynn("{saver.You} {saver.youAre} about to use a restraint key to unlock the slutwall.")
+
+	var acceptHelpProbability = getInmateAcceptHelpProbability()
+	var refuseHelpProbability = 1.0 - acceptHelpProbability
+	addAction("accept", "Accept", "Allow them to unlock the slutwall", "default", acceptHelpProbability, 60, {})
+	addAction("refuse", "Refuse", "You'd rather stay in the slutwall", "default", refuseHelpProbability, 60, {})
+
+func refusable_save_using_key_do(_id:String, _args:Dictionary, _context:Dictionary):
+	if(_id == "accept"):
+		saveUsingKey()
+	if(_id == "refuse"):
+		setState("refused_save", "saver")
+
+
+func refused_save_text():
+	saynn("{inmate.You} {inmate.youVerb('refuse', 'refused')} {saver.your} help.")
+	sayLine("inmate", "HelpStocksSlutwallRefuse", {main="inmate", target="saver"})
+
+	addAction("leave", "Leave", "Time to go", "default", 1.0, 60, {})
+
+func refused_save_do(_id:String, _args:Dictionary, _context:Dictionary):
 	if(_id == "leave"):
 		setState("canceled_save", "saver")
 
 
 func canceled_save_text():
-	saynn("{saver.name} is leaving, no longer trying to save {inmate.you}..")
+	if(immediatelyLeft):
+		saynn("{saver.You} {saver.youVerb('walk')} away, leaving {inmate.you} to {inmate.yourHis} fate..")
+	else:
+		saynn("{saver.You} {saver.youVerb('leave')}, no longer trying to save {inmate.you}..")
 
-	addAction("leave", "Leave", "Time to go", "default", 1.0, 60, {})
+	addAction("continue", "Continue", "See what happens next..", "default", 1.0, 30, {})
 
 func canceled_save_do(_id:String, _args:Dictionary, _context:Dictionary):
-	if(_id == "leave"):
+	if(_id == "continue"):
 		doRemoveRole("saver")
 		setState("", "inmate")
 
@@ -371,9 +413,10 @@ func doInterruptAction(_pawn:CharacterPawn, _id:String, _args:Dictionary, _conte
 		doInvolvePawn("user", _pawn)
 		setState("about_to_use", "user")
 	if(_id == "free"):
+		saveTryCount = 0
+		immediatelyLeft = false
 		doInvolvePawn("saver", _pawn)
 		setState("about_to_save", "saver")
-		saveTryCount = 0
 	if(_id == "free_slave"):
 		doInvolvePawn("saver", _pawn)
 		setState("free_slave", "inmate")
@@ -382,7 +425,7 @@ func doInterruptAction(_pawn:CharacterPawn, _id:String, _args:Dictionary, _conte
 func getAnimData() -> Array:
 	if(getState() in ["save_saved", "free_slave"]):
 		return [StageScene.Duo, "stand", {pc="inmate", npc="saver"}]
-	if(getState() in ["about_to_save", "save_after_help"]):
+	if(getState() in ["about_to_save", "refusable_save_using_stamina", "refusable_save_using_key", "refused_save", "save_after_help"]):
 		return [StageScene.SlutwallSex, "tease", {pc="inmate", npc="saver"}]
 	if(getState() in ["about_to_use", "after_use", "after_tip"]):
 		return [StageScene.SlutwallSex, "tease", {pc="inmate", npc="user"}]
@@ -399,7 +442,7 @@ func getPreviewLineForRole(_role:String) -> String:
 	if(_role == "inmate"):
 		if(getState() in ["about_to_use", "after_use"]):
 			return "{inmate.name} is being used by {user.name}.."
-		if(getState() in ["about_to_save", "save_after_help"]):
+		if(getState() in ["about_to_save", "refusable_save_using_stamina", "refusable_save_using_key", "save_after_help"]):
 			return "{inmate.name} is being saved by {saver.name}.."
 		return "{inmate.name} is stuck in a slutwall.."
 	if(_role == "user"):
@@ -416,6 +459,43 @@ func onStopped():
 	if(hasRoleChar("inmate")):
 		getRoleChar("inmate").getInventory().clearStaticRestraints()
 
+func getInmateAcceptHelpProbability() -> float:
+	var acceptHelpProbability:float = 1.0
+
+	if(shoutedForHelpCount > 0):
+		acceptHelpProbability = 1.0
+		return acceptHelpProbability
+
+	var inmateDommyness:float = getRolePawn("inmate").scorePersonalityMax({PersonalityStat.Subby: -1.0})
+	var saverDommyness:float = getRolePawn("saver").scorePersonalityMax({PersonalityStat.Subby: -1.0})
+	var dommynessDisadvantageRatio:float = max(saverDommyness - inmateDommyness, 0.0) / 2.0
+
+	acceptHelpProbability = clamp(1.0 - getRolePawn("inmate").scoreFetishMax({ Fetish.Bondage: 0.8 }) + 0.6 * dommynessDisadvantageRatio, 0.0, 1.0)
+	return acceptHelpProbability
+
+func saveUsingStamina() -> void:
+	saveTryCount += 1
+	var inmate = getRoleChar("inmate")
+	var struggleData:Dictionary = inmate.doStruggleOutOfRestraints(false, true, getRoleChar("saver"), 2.0)
+	if(struggleData.empty()):
+		struggleText = "Something happened.."
+	else:
+		struggleText = struggleData["text"]
+	
+	if(inmate.getInventory().hasItemIDEquipped("SlutwallStatic")):
+		setState("save_after_help", "inmate")
+	else:
+		savedHow = "help"
+		setState("save_saved", "inmate")
+		affectAffection("inmate", "saver", 0.2)
+
+func saveUsingKey() -> void:
+	savedHow = "key"
+	setState("save_saved", "inmate")
+	affectAffection("inmate", "saver", 0.2)
+	getRoleChar("saver").getInventory().removeXOfOrDestroy("restraintkey", 1)
+	getRoleChar("inmate").getInventory().clearStaticRestraints()
+
 func saveData():
 	var data = .saveData()
 
@@ -424,6 +504,8 @@ func saveData():
 	data["saveTryCount"] = saveTryCount
 	data["useCount"] = useCount
 	data["tips"] = tips
+	data["shoutedForHelpCount"] = shoutedForHelpCount
+	data["immediatelyLeft"] = immediatelyLeft
 	return data
 
 func loadData(_data):
@@ -434,4 +516,6 @@ func loadData(_data):
 	saveTryCount = SAVE.loadVar(_data, "saveTryCount", 0)
 	useCount = SAVE.loadVar(_data, "useCount", 0)
 	tips = SAVE.loadVar(_data, "tips", 0)
+	shoutedForHelpCount = SAVE.loadVar(_data, "shoutedForHelpCount", 0)
+	immediatelyLeft = SAVE.loadVar(_data, "immediatelyLeft", false)
 

--- a/Game/InteractionSystem/Interactions/InSlutwall.gd
+++ b/Game/InteractionSystem/Interactions/InSlutwall.gd
@@ -470,7 +470,7 @@ func getInmateAcceptHelpProbability() -> float:
 	var saverDommyness:float = getRolePawn("saver").scorePersonalityMax({PersonalityStat.Subby: -1.0})
 	var dommynessDisadvantageRatio:float = max(saverDommyness - inmateDommyness, 0.0) / 2.0
 
-	acceptHelpProbability = clamp(1.0 - getRolePawn("inmate").scoreFetishMax({ Fetish.Bondage: 0.8 }) + 0.6 * dommynessDisadvantageRatio, 0.0, 1.0)
+	acceptHelpProbability = clamp(1.0 - getRolePawn("inmate").scoreFetishMax({ Fetish.Bondage: 0.4 }) + 0.3 * dommynessDisadvantageRatio, 0.0, 1.0)
 	return acceptHelpProbability
 
 func saveUsingStamina() -> void:

--- a/Game/InteractionSystem/Interactions/InStocks.gd
+++ b/Game/InteractionSystem/Interactions/InStocks.gd
@@ -403,7 +403,7 @@ func getInmateAcceptHelpProbability() -> float:
 	var saverDommyness:float = getRolePawn("saver").scorePersonalityMax({PersonalityStat.Subby: -1.0})
 	var dommynessDisadvantageRatio:float = max(saverDommyness - inmateDommyness, 0.0) / 2.0
 
-	acceptHelpProbability = clamp(1.0 - getRolePawn("inmate").scoreFetishMax({ Fetish.Bondage: 0.8 }) + 0.6 * dommynessDisadvantageRatio, 0.0, 1.0)
+	acceptHelpProbability = clamp(1.0 - getRolePawn("inmate").scoreFetishMax({ Fetish.Bondage: 0.4 }) + 0.3 * dommynessDisadvantageRatio, 0.0, 1.0)
 	return acceptHelpProbability
 
 func saveUsingStamina() -> void:

--- a/Game/InteractionSystem/Interactions/InStocks.gd
+++ b/Game/InteractionSystem/Interactions/InStocks.gd
@@ -3,6 +3,8 @@ extends PawnInteractionBase
 var struggleText = ""
 var savedHow = ""
 var saveTryCount = 0
+var shoutedForHelpCount = 0
+var immediatelyLeft = false
 
 func _init():
 	id = "InStocks"
@@ -59,6 +61,7 @@ func init_do(_id:String, _args:Dictionary, _context:Dictionary):
 		checkSleep()
 		getCharByRole("inmate").addStamina(50)
 	if(_id == "shout"):
+		shoutedForHelpCount += 1
 		setState("about_to_shout", "inmate")
 	if(_id == "struggle"):
 		if(getRolePawn("inmate").isPlayer()):
@@ -129,7 +132,11 @@ func after_use_do(_id:String, _args:Dictionary, _context:Dictionary):
 
 
 func about_to_save_text():
-	saynn("{saver.name} approaches {inmate.you}!")
+	if(saveTryCount == 0):
+		saynn("{saver.You} {saver.youVerb('approach', 'approaches')} {inmate.you}!")
+	else:
+		saynn("{saver.You} {saver.youVerb('stand')} next to {inmate.you}.")
+
 	saynn("{saver.YouHe} can either spend some of {saver.yourHis} stamina and help {inmate.you} to struggle out of stocks.. or use a restraint key to unlock it.")
 
 	if(getRoleChar("saver").getStamina() > 0):
@@ -142,37 +149,72 @@ func about_to_save_text():
 
 func about_to_save_do(_id:String, _args:Dictionary, _context:Dictionary):
 	if(_id == "help"):
-		saveTryCount += 1
-		var inmate = getRoleChar("inmate")
-		var struggleData:Dictionary = inmate.doStruggleOutOfRestraints(false, true, getRoleChar("saver"), 2.0)
-		if(struggleData.empty()):
-			struggleText = "Something happened.."
+		if(saveTryCount == 0):
+			setState("refusable_save_using_stamina", "inmate")
 		else:
-			struggleText = struggleData["text"]
-		
-		if(inmate.getInventory().hasItemIDEquipped("StocksStatic")):
-			setState("save_after_help", "inmate")
-		else:
-			savedHow = "help"
-			setState("save_saved", "inmate")
-			affectAffection("inmate", "saver", 0.2)
+			saveUsingStamina()
 	if(_id == "key"):
-		savedHow = "key"
-		setState("save_saved", "inmate")
-		affectAffection("inmate", "saver", 0.2)
-		getRoleChar("saver").getInventory().removeXOfOrDestroy("restraintkey", 1)
-		getRoleChar("inmate").getInventory().clearStaticRestraints()
+		if(saveTryCount == 0):
+			setState("refusable_save_using_key", "inmate")
+		else:
+			saveUsingKey()
+	if(_id == "leave"):
+		if(saveTryCount == 0):
+			immediatelyLeft = true
+		setState("canceled_save", "saver")
+
+
+func refusable_save_using_stamina_text():
+	saynn("{saver.You} {saver.youAre} about to help {inmate.you} struggle out of stocks.")
+
+	var acceptHelpProbability = getInmateAcceptHelpProbability()
+	var refuseHelpProbability = 1.0 - acceptHelpProbability
+	addAction("accept", "Accept", "Allow them to help you", "default", acceptHelpProbability, 60, {})
+	addAction("refuse", "Refuse", "You'd rather stay in stocks", "default", refuseHelpProbability, 60, {})
+
+func refusable_save_using_stamina_do(_id:String, _args:Dictionary, _context:Dictionary):
+	if(_id == "accept"):
+		saveUsingStamina()
+	if(_id == "refuse"):
+		setState("refused_save", "saver")
+
+
+func refusable_save_using_key_text():
+	saynn("{saver.You} {saver.youAre} about to use a restraint key to unlock the stocks.")
+
+	var acceptHelpProbability = getInmateAcceptHelpProbability()
+	var refuseHelpProbability = 1.0 - acceptHelpProbability
+	addAction("accept", "Accept", "Allow them to unlock the stocks", "default", acceptHelpProbability, 60, {})
+	addAction("refuse", "Refuse", "You'd rather stay in stocks", "default", refuseHelpProbability, 60, {})
+
+func refusable_save_using_key_do(_id:String, _args:Dictionary, _context:Dictionary):
+	if(_id == "accept"):
+		saveUsingKey()
+	if(_id == "refuse"):
+		setState("refused_save", "saver")
+
+
+func refused_save_text():
+	saynn("{inmate.You} {inmate.youVerb('refuse', 'refused')} {saver.your} help.")
+	sayLine("inmate", "HelpStocksSlutwallRefuse", {main="inmate", target="saver"})
+
+	addAction("leave", "Leave", "Time to go", "default", 1.0, 60, {})
+
+func refused_save_do(_id:String, _args:Dictionary, _context:Dictionary):
 	if(_id == "leave"):
 		setState("canceled_save", "saver")
 
 
 func canceled_save_text():
-	saynn("{saver.name} is leaving, no longer trying to save {inmate.you}..")
+	if(immediatelyLeft):
+		saynn("{saver.You} {saver.youVerb('walk')} away, leaving {inmate.you} to {inmate.yourHis} fate..")
+	else:
+		saynn("{saver.You} {saver.youVerb('leave')}, no longer trying to save {inmate.you}..")
 
-	addAction("leave", "Leave", "Time to go", "default", 1.0, 60, {})
+	addAction("continue", "Continue", "See what happens next..", "default", 1.0, 30, {})
 
 func canceled_save_do(_id:String, _args:Dictionary, _context:Dictionary):
-	if(_id == "leave"):
+	if(_id == "continue"):
 		doRemoveRole("saver")
 		setState("", "inmate")
 
@@ -304,9 +346,10 @@ func doInterruptAction(_pawn:CharacterPawn, _id:String, _args:Dictionary, _conte
 		doInvolvePawn("user", _pawn)
 		setState("about_to_use", "user")
 	if(_id == "free"):
+		saveTryCount = 0
+		immediatelyLeft = false
 		doInvolvePawn("saver", _pawn)
 		setState("about_to_save", "saver")
-		saveTryCount = 0
 	if(_id == "free_slave"):
 		doInvolvePawn("saver", _pawn)
 		setState("free_slave", "inmate")
@@ -315,7 +358,7 @@ func doInterruptAction(_pawn:CharacterPawn, _id:String, _args:Dictionary, _conte
 func getAnimData() -> Array:
 	if(getState() in ["save_saved", "free_slave"]):
 		return [StageScene.Duo, "stand", {pc="inmate", npc="saver"}]
-	if(getState() in ["about_to_save", "save_after_help"]):
+	if(getState() in ["about_to_save", "refusable_save_using_stamina", "refusable_save_using_key", "refused_save", "save_after_help"]):
 		return [StageScene.StocksSexOral, "tease", {pc="inmate", npc="saver"}]
 	if(getState() in ["about_to_use", "after_use"]):
 		return [StageScene.StocksSexOral, "tease", {pc="inmate", npc="user"}]
@@ -332,7 +375,7 @@ func getPreviewLineForRole(_role:String) -> String:
 	if(_role == "inmate"):
 		if(getState() in ["about_to_use", "after_use"]):
 			return "{inmate.name} is being used by {user.name}.."
-		if(getState() in ["about_to_save", "save_after_help"]):
+		if(getState() in ["about_to_save", "refusable_save_using_stamina", "refusable_save_using_key", "save_after_help"]):
 			return "{inmate.name} is being saved by {saver.name}.."
 		return "{inmate.name} is stuck in stocks.."
 	if(_role == "user"):
@@ -349,12 +392,51 @@ func onStopped():
 	if(hasRoleChar("inmate")):
 		getRoleChar("inmate").getInventory().clearStaticRestraints()
 
+func getInmateAcceptHelpProbability() -> float:
+	var acceptHelpProbability:float = 1.0
+
+	if(shoutedForHelpCount > 0):
+		acceptHelpProbability = 1.0
+		return acceptHelpProbability
+
+	var inmateDommyness:float = getRolePawn("inmate").scorePersonalityMax({PersonalityStat.Subby: -1.0})
+	var saverDommyness:float = getRolePawn("saver").scorePersonalityMax({PersonalityStat.Subby: -1.0})
+	var dommynessDisadvantageRatio:float = max(saverDommyness - inmateDommyness, 0.0) / 2.0
+
+	acceptHelpProbability = clamp(1.0 - getRolePawn("inmate").scoreFetishMax({ Fetish.Bondage: 0.8 }) + 0.6 * dommynessDisadvantageRatio, 0.0, 1.0)
+	return acceptHelpProbability
+
+func saveUsingStamina() -> void:
+	saveTryCount += 1
+	var inmate = getRoleChar("inmate")
+	var struggleData:Dictionary = inmate.doStruggleOutOfRestraints(false, true, getRoleChar("saver"), 2.0)
+	if(struggleData.empty()):
+		struggleText = "Something happened.."
+	else:
+		struggleText = struggleData["text"]
+	
+	if(inmate.getInventory().hasItemIDEquipped("StocksStatic")):
+		setState("save_after_help", "inmate")
+	else:
+		savedHow = "help"
+		setState("save_saved", "inmate")
+		affectAffection("inmate", "saver", 0.2)
+
+func saveUsingKey() -> void:
+	savedHow = "key"
+	setState("save_saved", "inmate")
+	affectAffection("inmate", "saver", 0.2)
+	getRoleChar("saver").getInventory().removeXOfOrDestroy("restraintkey", 1)
+	getRoleChar("inmate").getInventory().clearStaticRestraints()
+
 func saveData():
 	var data = .saveData()
 
 	data["struggleText"] = struggleText
 	data["savedHow"] = savedHow
 	data["saveTryCount"] = saveTryCount
+	data["shoutedForHelpCount"] = shoutedForHelpCount
+	data["immediatelyLeft"] = immediatelyLeft
 	return data
 
 func loadData(_data):
@@ -363,4 +445,6 @@ func loadData(_data):
 	struggleText = SAVE.loadVar(_data, "struggleText", "")
 	savedHow = SAVE.loadVar(_data, "savedHow", "")
 	saveTryCount = SAVE.loadVar(_data, "saveTryCount", 0)
+	shoutedForHelpCount = SAVE.loadVar(_data, "shoutedForHelpCount", 0)
+	immediatelyLeft = SAVE.loadVar(_data, "immediatelyLeft", false)
 

--- a/Game/ModularDialogue/Fillers/DefaultFiller.gd
+++ b/Game/ModularDialogue/Fillers/DefaultFiller.gd
@@ -42,12 +42,16 @@ func getFormIDs() -> Array:
 		"HelpRestraintsAsk",
 		"HelpRestraintsAgree",
 		"HelpRestraintsAltStart",
+		"HelpRestraintsAltRefuseUnhappy",
+		"HelpRestraintsAltRefuseKinky",
+		"HelpRestraintsAltRefuseKinkyReact",
 		"HelpRestraintsDeny",
 		"HelpRestraintsFinished",
 		"HelpRestraintsPaid",
 		"HelpRestraintsRefusePay",
 		"HelpRestraintsRefusePayWhatever",
 		
+		"HelpStocksSlutwallRefuse",
 		"SlutwallStealCredits",
 		"SlutwallAddTip",
 		"StocksShout",
@@ -510,12 +514,42 @@ func getText(_id:String, _args:Dictionary):
 			"Sure, I can try.",
 		]
 	if(_id == "HelpRestraintsAltStart"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
 		return [
-			"Hey there, let me help you with those. Hold still.",
+			"Hey there, let me help you with "+restraint_thatThose+". Hold still.",
 			"Let me help you with your gear.",
-			"I want to help you with those. Hold tight.",
-			"I’ll help with those. Don’t move.",
-			"I’m going to help you out with those. Hang on.",
+			"I want to help you with "+restraint_thatThose+". Hold tight.",
+			"I’ll help with "+restraint_thatThose+". Don’t move.",
+			"I’m going to help you out with "+restraint_thatThose+". Hang on.",
+		]
+	if(_id == "HelpRestraintsAltRefuseUnhappy"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		var restraint_it_sThey_re = "it's" if(!restraintIsPlural) else "they're"
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		return [
+			"I appreciate the thought, but I don't want you taking "+restraint_itThem+" off.",
+			( "That stays" if(!restraintIsPlural) else "Those stay" )+" on.",
+			"I don't want you taking "+restraint_thatThose+" off, "+restraint_it_sThey_re+" quite comfy..",
+			"I'm feeling like keeping "+restraint_thatThose+" for a little longer.",
+			( "It doesn't" if(!restraintIsPlural) else "These don't" )+" really bother me.",
+			"I've honestly forgotten I was still wearing "+restraint_thatThose+". "+( "It feels" if(!restraintIsPlural) else "They feel" )+" so natural.",
+		]
+	if(_id == "HelpRestraintsAltRefuseKinky"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		return [
+			"Oh, I'm only wearing "+restraint_thatThose+" because I want to.",
+			"Hey, there's no need. I like having "+restraint_itThem+" on~.",
+			"I wanted to get rid of "+restraint_thatThose+" at first, but I think I'm starting to like "+restraint_itThem+"..",
+			( "It fits" if(!restraintIsPlural) else "They fit" )+" me so well, perhaps what you should be doing is adoring "+restraint_itThem+" close and intimate~.",
+		]
+	if(_id == "HelpRestraintsAltRefuseKinkyReact"):
+		return [
+			"Kinky.",
+			"Mmm, that's hot.",
 		]
 	if(_id == "HelpRestraintsDeny"):
 		return [
@@ -563,6 +597,16 @@ func getText(_id:String, _args:Dictionary):
 			"Whatever, it’s not worth arguing.",
 			"Whatever, have it your way.",
 			"Okay, whatever, I don’t care.",
+		]
+	if(_id == "HelpStocksSlutwallRefuse"):
+		return [
+			"Don't worry, I'm more than enjoying this.",
+			"I've yet to get my share of fun out of this.",
+			"Oh, you don't have to. I'm fine, really.",
+			"There are still so many inmates I want to meet, and.. really get to know them..",
+			"Thanks, but I'm not looking for an easy way out.",
+			"I can take this.. Surely..",
+			"I know I look really helpless in here, but that's kind of the point, y'know?",
 		]
 	if(_id == "SlutwallStealCredits"):
 		return [

--- a/Game/ModularDialogue/Fillers/Dommy.gd
+++ b/Game/ModularDialogue/Fillers/Dommy.gd
@@ -45,12 +45,16 @@ func getFormIDs() -> Array:
 		"HelpRestraintsAsk",
 		"HelpRestraintsAgree",
 		"HelpRestraintsAltStart",
+		"HelpRestraintsAltRefuseUnhappy",
+		"HelpRestraintsAltRefuseKinky",
+		"HelpRestraintsAltRefuseKinkyReact",
 		"HelpRestraintsDeny",
 		"HelpRestraintsFinished",
 		"HelpRestraintsPaid",
 		"HelpRestraintsRefusePay",
 		"HelpRestraintsRefusePayWhatever",
 		
+		"HelpStocksSlutwallRefuse",
 		"SlutwallStealCredits",
 		"SlutwallAddTip",
 		"StocksShout",
@@ -510,11 +514,38 @@ func getText(_id:String, _args:Dictionary):
 			"Sure, I’ll take care of it. But you better remember who’s in charge.",
 		]
 	if(_id == "HelpRestraintsAltStart"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
 		return [
 			"Sit tight, cutie, let me help you.",
-			"Don’t move, sweet thing, I’ll handle these toys that you got.",
-			"Be a good slut and let me take care of those.",
+			"Don’t move, sweet thing, I’ll handle "+( "this toy" if(!restraintIsPlural) else "these toys" )+" that you got.",
+			"Be a good slut and let me take care of "+restraint_thatThose+".",
 			"Keep still, pet. I’ll get you out in a second.",
+		]
+	if(_id == "HelpRestraintsAltRefuseUnhappy"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		# var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		var restraint_That_sThose_are = "That's" if(!restraintIsPlural) else "Those are"
+		return [
+			"Thanks for looking out for me, but that's something I'd like to keep.",
+			"You want "+restraint_itThem+" for yourself, don't you? "+restraint_That_sThose_are+" mine.",
+			( "That stays" if(!restraintIsPlural) else "Those stay" )+" on, darling.",
+			"A pet like you should know how comfy "+( "it is in one of those" if(!restraintIsPlural) else "those are" )+"."
+		]
+	if(_id == "HelpRestraintsAltRefuseKinky"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		return [
+			"That's very nice of you.. but I would rather keep wearing "+restraint_itThem+".",
+			"I'm wearing "+restraint_thatThose+" by my own choice, cutie.",
+			"There are better ways to serve me~.",
+			"You want "+( "one of those" if(!restraintIsPlural) else "those" )+" for yourself, don't you? Get on your knees and I might have some gear just for you~.",
+		]
+	if(_id == "HelpRestraintsAltRefuseKinkyReact"):
+		return [
+			"Adorable.",
 		]
 	if(_id == "HelpRestraintsDeny"):
 		return [
@@ -561,6 +592,17 @@ func getText(_id:String, _args:Dictionary):
 			"Sure, have it your way. Still pathetic.",
 			"Alright, cry about it.",
 			"Yeah, whatever, not my problem.",
+		]
+	if(_id == "HelpStocksSlutwallRefuse"):
+		return [
+			"It's quite comfy in here, you should try it~.",
+			"How about you join me here instead?~.",
+			"It's true you belong here more than I do, but you can't keep all the fun to yourself~.",
+			"Don't worry about me, even this locked and vulnerable, everyone still obeys my commands.",
+			"Aww, that's sweet of you.. yet I feel there's more fun for me to be had here~.",
+			"This is.. quite an experience. Don't bring it to an end for me just yet, will you?~.",
+			"I might not be a fucktoy like you, but right now I'm exactly where I want to be~.",
+			"Miss me already? You'll get to arch your back for me soon enough, let me relax a little longer~.",
 		]
 	if(_id == "SlutwallStealCredits"):
 		return [

--- a/Game/ModularDialogue/Fillers/Mean.gd
+++ b/Game/ModularDialogue/Fillers/Mean.gd
@@ -45,12 +45,16 @@ func getFormIDs() -> Array:
 		"HelpRestraintsAsk",
 		"HelpRestraintsAgree",
 		"HelpRestraintsAltStart",
+		"HelpRestraintsAltRefuseUnhappy",
+		"HelpRestraintsAltRefuseKinky",
+		"HelpRestraintsAltRefuseKinkyReact",
 		"HelpRestraintsDeny",
 		"HelpRestraintsFinished",
 		"HelpRestraintsPaid",
 		"HelpRestraintsRefusePay",
 		"HelpRestraintsRefusePayWhatever",
 		
+		"HelpStocksSlutwallRefuse",
 		"SlutwallStealCredits",
 		"SlutwallAddTip",
 		"StocksShout",
@@ -523,12 +527,43 @@ func getText(_id:String, _args:Dictionary):
 			"Yeah, I can do that. Just stop whining.",
 		]
 	if(_id == "HelpRestraintsAltStart"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
 		return [
-			"Hold still, slut. I’ll get you out of those, if you behave.",
+			"Hold still, slut. I’ll get you out of "+restraint_thatThose+", if you behave.",
 			"Don’t move a muscle, I’ll deal with your pathetic situation.",
 			"I’ll help you out, but don’t you dare move a fucking inch.",
 			"Sit tight, I’ll handle it. You’re lucky I’m feeling generous.",
 			"Stay put, slut. I’m in control now.",
+		]
+	if(_id == "HelpRestraintsAltRefuseUnhappy"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		return [
+			"You didn't think to ask if I want to keep "+restraint_thatThose+"?",
+			"I didn't ask for your help.",
+			"Don't you fucking touch "+restraint_thatThose+".",
+			"If you see me wearing "+restraint_itThem+", then clearly "+( "it's not fucking yours, is it?" if(!restraintIsPlural) else "they're not fucking yours, are they?" ),
+			"You want to keep snatching my gear, one by one, until I look like a basic bitch? Nah, piss off.",
+			"Even a whore like you should have no problem grasping why I might want to keep "+restraint_thatThose+" on.",
+			( "That restraint means" if(!restraintIsPlural) else "Those mean") +" something to me. A whore like you wouldn't understand.",
+		]
+	if(_id == "HelpRestraintsAltRefuseKinky"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		# var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		var restraint_that_sThose_are = "that's" if(!restraintIsPlural) else "those are"
+		return [
+			"Mm, quite a helpful slut. But "+restraint_that_sThose_are+" mine to wear.",
+			"If you're trying to make yourself useful, you're better off serving me as a fucktoy.",
+			"No need. But if you're looking to make yourself useful, there are better ways for a slut like you to serve me.",
+			"Have some patience, bitch. It'll be your turn to wear "+restraint_thatThose+" soon enough.",
+		]
+	if(_id == "HelpRestraintsAltRefuseKinkyReact"):
+		return [
+			"Right, almost forgot you're a slut.",
+			"Should have expected that from a whore like you.",
 		]
 	if(_id == "HelpRestraintsDeny"):
 		return [
@@ -575,6 +610,20 @@ func getText(_id:String, _args:Dictionary):
 			"Yeah, whatever. Like I care.",
 			"Whatever, fuck off already.",
 			"Sure, whatever, get lost.",
+		]
+	if(_id == "HelpStocksSlutwallRefuse"):
+		return [
+			"I'm not entrusting this to a slut like you.",
+			"With your strength? I'm not waiting a fucking week.",
+			"If you're not here to fuck me, then stop wasting my time.",
+			"Nobody needs your help. Get lost.",
+			"You can make yourself useful by vacating the damn spot.",
+			"You've heard me calling for help? No you fucking didn't.",
+			"Can't you see this spot is taken? Find your fucking own.",
+			"Bitch, you're in the way of my audience. Be on your fucking way.",
+			"Did it not occur to you that I might prefer staying like this?",
+			"Don't fucking touch me.",
+			"Get your dirty hands off me.",
 		]
 	if(_id == "SlutwallStealCredits"):
 		return [

--- a/Game/ModularDialogue/Fillers/ShySubby.gd
+++ b/Game/ModularDialogue/Fillers/ShySubby.gd
@@ -45,12 +45,16 @@ func getFormIDs() -> Array:
 		"HelpRestraintsAsk",
 		"HelpRestraintsAgree",
 		"HelpRestraintsAltStart",
+		"HelpRestraintsAltRefuseUnhappy",
+		"HelpRestraintsAltRefuseKinky",
+		"HelpRestraintsAltRefuseKinkyReact",
 		"HelpRestraintsDeny",
 		"HelpRestraintsFinished",
 		"HelpRestraintsPaid",
 		"HelpRestraintsRefusePay",
 		"HelpRestraintsRefusePayWhatever",
 		
+		"HelpStocksSlutwallRefuse",
 		"SlutwallStealCredits",
 		"SlutwallAddTip",
 		"StocksShout",
@@ -492,12 +496,43 @@ func getText(_id:String, _args:Dictionary):
 			"Sure, I’ll help with that..",
 		]
 	if(_id == "HelpRestraintsAltStart"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
 		return [
-			"Hi, let me help you with those.. Please?..",
-			"I’m can help with those restraints.. Please hold on.",
+			"Hi, let me help you with "+restraint_thatThose+".. Please?..",
+			"I can help with "+( "this restraint" if(!restraintIsPlural) else "those restraints" )+".. Please hold on.",
 			"Let me take care of that for you. Don’t move, okay?..",
-			"I’ll help you with your restraints. Just stay calm..",
-			"Hang on, I’ll work on those restraints for you.. if that's okay..",
+			"I’ll help you with your "+( "restraint" if(!restraintIsPlural) else "restraints" )+". Just stay calm..",
+			"Hang on, I’ll work on "+( "this restraint" if(!restraintIsPlural) else "those restraints" )+" for you.. if that's okay..",
+		]
+	if(_id == "HelpRestraintsAltRefuseUnhappy"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		return [
+			"N-Not yet, I want to wear "+restraint_itThem+" for a l-little longer.",
+			"I don't n-need your help.. T-Thank you.",
+			"I love when you make decisions on m-my behalf, really.. But I'd like to keep "+restraint_thatThose+".",
+			"T-Thank you, but there's no need..",
+		]
+	if(_id == "HelpRestraintsAltRefuseKinky"):
+		var restraintIsPlural = getVar(_args, "restraintIsPlural", false)
+		var restraint_itThem = "it" if(!restraintIsPlural) else "them"
+		var restraint_itThey = "it" if(!restraintIsPlural) else "they"
+		var restraint_thatThose = "that" if(!restraintIsPlural) else "those"
+		return [
+			"I want to keep "+restraint_thatThose+" for a little longer, if you don't mind.. It's a reminder of all the fun I had.",
+			"Please let me keep "+restraint_thatThose+".. I love having "+restraint_itThem+" on display.",
+			"I-I was told I'm not allowed to take "+restraint_itThem+" off..",
+			"It actually means a lot to me to wear "+restraint_thatThose+"..",
+			( "It was" if(!restraintIsPlural) else "They were" )+" gifted to me. Wearing "+restraint_itThem+" is my responsibility.",
+			"There is n-no need. It's like.. "+restraint_itThey+" became an inseparable part of what I am..",
+			"Y-You shouldn't.. I like having "+restraint_itThem+" on..",
+		]
+	if(_id == "HelpRestraintsAltRefuseKinkyReact"):
+		return [
+			"O-Oh, okay..",
+			"H-Hot..",
 		]
 	if(_id == "HelpRestraintsDeny"):
 		return [
@@ -537,6 +572,18 @@ func getText(_id:String, _args:Dictionary):
 			"Alright, whatever. I’ll let it go.",
 			"Whatever, I’m not going to argue about it.",
 			"Okay, forget it. I don’t care anymore.",
+		]
+	if(_id == "HelpStocksSlutwallRefuse"):
+		return [
+			"You're kidding me, right? This is like heaven for me.",
+			"Don't bother, I would find a way to get stuck again.",
+			"I-I don't need saving, I just need someone to fill me..",
+			"L-Look.. I finally found my place, it's right here..",
+			"Aww, you're so nice.. But this is where I belong.",
+			"I-I feel safer here.. Everyone is so rude when I wander around..",
+			"Being able to walk around is nice, b-but.. public use.. hhh..",
+			"Y-You haven't used me enough..",
+			"I-I deserve the punishment.. I should h-have known better..",
 		]
 	if(_id == "SlutwallStealCredits"):
 		return [

--- a/Game/ModularDialogue/FormBanks/Default.gd
+++ b/Game/ModularDialogue/FormBanks/Default.gd
@@ -51,12 +51,16 @@ func getForms() -> Dictionary:
 		"HelpRestraintsAsk": form("Hey. Can you help me with these restraints maybe?", {main=CHAR, target=CHAR}, "main", "target"),
 		"HelpRestraintsAgree": form("Sure. Let's see what I can do.", {main=CHAR, target=CHAR}, "main", "target"),
 		"HelpRestraintsAltStart": form("Hey. I wanna help you with these restraints. Sit tight.", {main=CHAR, target=CHAR}, "main", "target"),
+		"HelpRestraintsAltRefuseUnhappy": form("I don't want your help with restraints.", {main=CHAR, target=CHAR}, "main", "target"),
+		"HelpRestraintsAltRefuseKinky": form("Oh, I'm only wearing those because I want to.", {main=CHAR, target=CHAR}, "main", "target"),
+		"HelpRestraintsAltRefuseKinkyReact": form("Kinky.", {main=CHAR, target=CHAR}, "main", "target"),
 		"HelpRestraintsDeny": form("No can't do. You will have to stay locked.", {main=CHAR, target=CHAR}, "main", "target"),
 		"HelpRestraintsFinished": form("That's all that I can do.", {main=CHAR, target=CHAR}, "main", "target"),
 		"HelpRestraintsPaid": form("That will do. I will go now.", {main=CHAR, target=CHAR}, "main", "target"),
 		"HelpRestraintsRefusePay": form("I'm not paying! You didn't even do that much.", {main=CHAR, target=CHAR}, "main", "target"),
 		"HelpRestraintsRefusePayWhatever": form("Whatever then.", {main=CHAR, target=CHAR}, "main", "target"),
 		
+		"HelpStocksSlutwallRefuse": form("I don't want your help breaking free.", {main=CHAR, target=CHAR}, "main", "target"),
 		"SlutwallStealCredits": form("A whore like you doesn't deserve these credits.", {main=CHAR, target=CHAR}, "main", "target"), # Stealing from the slutwall's tipbox
 		"SlutwallAddTip": form("There you go. What a good fucktoy.", {main=CHAR, target=CHAR}, "main", "target"), # Getting tipped after being used in a slutwall
 		"StocksShout": form("Anyone? I need some help over here.", {main=CHAR}, "main"), # Stuck in stocks, trying to get some attention


### PR DESCRIPTION
Pawns always assume their help with restraints is wanted. With the changes in this PR, offering to help someone with restraints prompts them on whether they wish to be helped, with the name of the restraint being displayed in the event log.

Stocks/Slutwall already has an ability to prevent help, but not before the initial attempt was already made. It's now possible to stop them in anticipation, featuring some dialogue lines added for extra flavor.

NPC's may refuse being helped if they are into bondage and the helping character doesn't have dommyness advantage over them. They will not refuse help if they shouted for help at least once.

\-

Fixes other restraints being removed when someone is being helped to struggle out of stocks or the slutwall, by giving priority to the latter.