### PR TITLE
Fix bad handling of ovulation after species get removed (like when modding)

### DIFF
--- a/Game/Pregnancy/MenstrualCycle.gd
+++ b/Game/Pregnancy/MenstrualCycle.gd
@@ -212,7 +212,10 @@ func ovulate():
 	var possibleEggAmounts = []
 	for specie in motherSpecies:
 		var speciesObject = GlobalRegistry.getSpecies(specie)
-		possibleEggAmounts.append_array(speciesObject.getEggCellOvulationAmount())
+		if speciesObject == null:
+			possibleEggAmounts.append_array([[1, 10.0],[2, 1.0]])
+		else:
+			possibleEggAmounts.append_array(speciesObject.getEggCellOvulationAmount())
 	
 	for orifice in OrificeType.getAll():
 		if(!hasWombIn(orifice)):


### PR DESCRIPTION
Game generally handles missing elements after save gets opened without mods fine, however when testing some modding stuff I found that this part of code can throw null if species is not found in registry and crash badly. 

This PR uses static default ovulation from BaseSpecies.gd when species doesn't exist preventing the crash.

If this is not the best way to do that I can change it, however that's the only thing I came up with. 