### PR TITLE
Skip dialogue when applying lube (or a modded drug/lube)

### DIFF
--- a/Game/SexEngine/SexActivity/DomDrugUse.gd
+++ b/Game/SexEngine/SexActivity/DomDrugUse.gd
@@ -196,7 +196,11 @@ func startActivity(_args):
 		
 		if(getSub().isPlayer() && itemID == "TFPill"):
 			text += " [color=#"+Color.cyan.to_html()+"]This pill might do something to your body[/color]"
-		return {text = text, domSay=domReaction(SexReaction.ForcingDrug)}
+
+		if(_isCanApply):
+			return {text = text}
+		else:
+			return {text = text, domSay=domReaction(SexReaction.ForcingDrug)}
 	
 	if(_args[0] == "useonself"):
 		timePassed = 0


### PR DESCRIPTION
when applying lube, dom would say one of those things

https://github.com/Alexofp/BDCC/blob/f1c6a2bb8fabf22601a467249a74bca977022b7a/Game/SexEngine/SexVoice.gd#L723-L730

could write some generic phrases like "Let's get you ready.." that would still make sense with potential modded items but i'm not creative enough right now x3

so this change just omits the dialogue for now