### PR TITLE
Fix "namehere is in a AloneInteraction interaction"

### DIFF
--- a/Game/InteractionSystem/Interactions/AloneInteraction.gd
+++ b/Game/InteractionSystem/Interactions/AloneInteraction.gd
@@ -242,6 +242,8 @@ func getPreviewLineForRole(_role:String) -> String:
 	if(_role == "main"):
 		if(goal != null):
 			return goal.getText().split("\n")[0]
+		else:
+			return "{main.name} is deciding what to do next.."
 	return .getPreviewLineForRole(_role)
 
 func getActivityIconForRole(_role:String):


### PR DESCRIPTION
i'll miss walking up to someone just to learn they're "in a AloneInteraction interaction" but it's probably worth a fix x3