### PR TITLE
Gain much less affection when freeing someone you locked up in stocks/slutwall

### DIFF
--- a/Game/InteractionSystem/Interactions/InSlutwall.gd
+++ b/Game/InteractionSystem/Interactions/InSlutwall.gd
@@ -1,12 +1,13 @@
 extends PawnInteractionBase
 
-var struggleText = ""
-var savedHow = ""
-var saveTryCount = 0
-var useCount = 0
-var tips = 0
-var shoutedForHelpCount = 0
-var immediatelyLeft = false
+var punisherID:String = ""
+var struggleText:String = ""
+var savedHow:String = ""
+var saveTryCount:int = 0
+var useCount:int = 0
+var tips:int = 0
+var shoutedForHelpCount:int = 0
+var immediatelyLeft:bool = false
 
 func _init():
 	id = "InSlutwall"
@@ -15,6 +16,9 @@ func start(_pawns:Dictionary, _args:Dictionary):
 	doInvolvePawn("inmate", _pawns["inmate"])
 	setState("", "inmate")
 	getCharByRole("inmate").getInventory().forceEquipRemoveOther(GlobalRegistry.createItem("SlutwallStatic"))
+
+	if( _args.has("punisherID") ):
+		punisherID = _args["punisherID"]
 
 func init_text():
 	saynn("{inmate.You} {inmate.youAre} stuck in the slutwall. {inmate.YouHe} {inmate.youAre} completely helpless with {inmate.yourHis} {inmate.thick} {butt} sticking out, free for anyone to fuck..")
@@ -487,18 +491,23 @@ func saveUsingStamina() -> void:
 	else:
 		savedHow = "help"
 		setState("save_saved", "inmate")
-		affectAffection("inmate", "saver", 0.2)
+		affectAffectionOnSave()
 
 func saveUsingKey() -> void:
 	savedHow = "key"
 	setState("save_saved", "inmate")
-	affectAffection("inmate", "saver", 0.2)
+	affectAffectionOnSave()
 	getRoleChar("saver").getInventory().removeXOfOrDestroy("restraintkey", 1)
 	getRoleChar("inmate").getInventory().clearStaticRestraints()
+
+func affectAffectionOnSave() -> void:
+	var affectionGain:float = 0.05 if(getRoleChar("saver").getID() == punisherID) else 0.2
+	affectAffection("inmate", "saver", affectionGain)
 
 func saveData():
 	var data = .saveData()
 
+	data["punisherID"] = punisherID
 	data["struggleText"] = struggleText
 	data["savedHow"] = savedHow
 	data["saveTryCount"] = saveTryCount
@@ -511,6 +520,7 @@ func saveData():
 func loadData(_data):
 	.loadData(_data)
 
+	punisherID = SAVE.loadVar(_data, "punisherID", "")
 	struggleText = SAVE.loadVar(_data, "struggleText", "")
 	savedHow = SAVE.loadVar(_data, "savedHow", "")
 	saveTryCount = SAVE.loadVar(_data, "saveTryCount", 0)

--- a/Game/InteractionSystem/Interactions/InStocks.gd
+++ b/Game/InteractionSystem/Interactions/InStocks.gd
@@ -1,10 +1,11 @@
 extends PawnInteractionBase
 
-var struggleText = ""
-var savedHow = ""
-var saveTryCount = 0
-var shoutedForHelpCount = 0
-var immediatelyLeft = false
+var punisherID:String = ""
+var struggleText:String = ""
+var savedHow:String = ""
+var saveTryCount:int = 0
+var shoutedForHelpCount:int = 0
+var immediatelyLeft:bool = false
 
 func _init():
 	id = "InStocks"
@@ -13,6 +14,9 @@ func start(_pawns:Dictionary, _args:Dictionary):
 	doInvolvePawn("inmate", _pawns["inmate"])
 	setState("", "inmate")
 	getCharByRole("inmate").getInventory().forceEquipRemoveOther(GlobalRegistry.createItem("StocksStatic"))
+
+	if( _args.has("punisherID") ):
+		punisherID = _args["punisherID"]
 
 func init_text():
 	saynn("{inmate.You} {inmate.youAre} stuck in stocks, there is very little {inmate.youHe} can do, the movement of {inmate.yourHis} head and arms is blocked by a giant metal frame with 3 holes, its angle is forcing {inmate.youHe} to constantly stay bent forward, exposing {inmate.yourHis} butt, your ankles are chained so {inmate.youHe} can’t really move them too. {inmate.YouHe} {inmate.youAre} completely helpless.")
@@ -420,18 +424,23 @@ func saveUsingStamina() -> void:
 	else:
 		savedHow = "help"
 		setState("save_saved", "inmate")
-		affectAffection("inmate", "saver", 0.2)
+		affectAffectionOnSave()
 
 func saveUsingKey() -> void:
 	savedHow = "key"
 	setState("save_saved", "inmate")
-	affectAffection("inmate", "saver", 0.2)
+	affectAffectionOnSave()
 	getRoleChar("saver").getInventory().removeXOfOrDestroy("restraintkey", 1)
 	getRoleChar("inmate").getInventory().clearStaticRestraints()
+
+func affectAffectionOnSave() -> void:
+	var affectionGain:float = 0.05 if(getRoleChar("saver").getID() == punisherID) else 0.2
+	affectAffection("inmate", "saver", affectionGain)
 
 func saveData():
 	var data = .saveData()
 
+	data["punisherID"] = punisherID
 	data["struggleText"] = struggleText
 	data["savedHow"] = savedHow
 	data["saveTryCount"] = saveTryCount
@@ -442,6 +451,7 @@ func saveData():
 func loadData(_data):
 	.loadData(_data)
 
+	punisherID = SAVE.loadVar(_data, "punisherID", "")
 	struggleText = SAVE.loadVar(_data, "struggleText", "")
 	savedHow = SAVE.loadVar(_data, "savedHow", "")
 	saveTryCount = SAVE.loadVar(_data, "saveTryCount", 0)

--- a/Game/InteractionSystem/Interactions/PunishInteraction.gd
+++ b/Game/InteractionSystem/Interactions/PunishInteraction.gd
@@ -121,7 +121,7 @@ func in_stocks_text():
 func in_stocks_do(_id:String, _args:Dictionary, _context:Dictionary):
 	if(_id == "leave"):
 		stopMe()
-		startInteraction("InStocks", {inmate=getRoleID("target")})
+		startInteraction("InStocks", {inmate=getRoleID("target")}, {punisherID=getRoleID("punisher")})
 
 
 func after_sex_text():
@@ -189,7 +189,7 @@ func in_slutwall_text():
 func in_slutwall_do(_id:String, _args:Dictionary, _context:Dictionary):
 	if(_id == "leave"):
 		stopMe()
-		startInteraction("InSlutwall", {inmate=getRoleID("target")})
+		startInteraction("InSlutwall", {inmate=getRoleID("target")}, {punisherID=getRoleID("punisher")})
 
 
 func getAnimData() -> Array:


### PR DESCRIPTION
too easy to farm affection locking someone up then freeing them with restraint key ^^;

approximate numbers with this fix:
\- locked someone up: 29% -> 7%
\- freed them afterwards: 7% -> 22% (before fix you'd get approx. 80%)

this should also work for npcs saving another npc they locked up