### PR TITLE
Reversible and slightly more precise zoom

### DIFF
--- a/Game/Datapacks/UI/CrotchCode/UI/AnimPickerWidget.gd
+++ b/Game/Datapacks/UI/CrotchCode/UI/AnimPickerWidget.gd
@@ -294,9 +294,9 @@ func a_gui_input(event: InputEvent):
 	
 	if event is InputEventMouseButton:
 		if(event.button_index == BUTTON_WHEEL_UP):
-			camera3d.size *= 0.9
+			camera3d.size *= 0.97
 		if(event.button_index == BUTTON_WHEEL_DOWN):
-			camera3d.size *= 1.1
+			camera3d.size /= 0.97
 	
 	if event is InputEventMouseButton:
 		if event.pressed:

--- a/Game/PlayerPanel.gd
+++ b/Game/PlayerPanel.gd
@@ -81,9 +81,9 @@ func _gui_input(event: InputEvent):
 	
 	if event is InputEventMouseButton:
 		if(event.button_index == BUTTON_WHEEL_UP):
-			camera3d.size *= 0.9
+			camera3d.size *= 0.97
 		if(event.button_index == BUTTON_WHEEL_DOWN):
-			camera3d.size *= 1.1
+			camera3d.size /= 0.97
 	
 	if event is InputEventMouseButton:
 		if event.pressed:

--- a/Game/World/World.gd
+++ b/Game/World/World.gd
@@ -336,7 +336,7 @@ func aimCamera(roomID, instantly = false):
 		camera.reset_smoothing()
 
 func zoomIn(mult:float = 1.0):
-	camera.zoom *= 1.1 * mult
+	camera.zoom /= 0.9 / mult
 	updateDarknessSize()
 
 func zoomOut(mult:float = 1.0):


### PR DESCRIPTION
very smol annoyance but i didn't know pressing the middle mouse button resets the zoom so whenever i tried to restore previous zoom it would be messed up

without change it goes like: 1.00 -> 0.90 -> 0.99 -> 0.89 -> 0.98

with change it goes: 1.00 -> 0.90 -> 1.00

\-

also compared to the minimap, 0.90 for the character model view seems too sharp of a change, so i suggest 0.97 (which is still pretty strong)