### PR TITLE
"OBEY" accepts/swallows pill

### DIFF
--- a/Game/SexEngine/SexActivity/DomDrugUse.gd
+++ b/Game/SexEngine/SexActivity/DomDrugUse.gd
@@ -384,32 +384,39 @@ func getSubActions():
 	var actions = []
 	if(state == "offering"):
 		var drugInfo = getDrugInfo(usedItemID, usedUniqueItemID)
-		var theScore = subInfo.personalityScore({PersonalityStat.Naive: 0.2, PersonalityStat.Subby: 0.2}) + subInfo.fetishScore({Fetish.DrugUse: 1.0})
+		var theObeyScore:float = subInfo.personalityScore({PersonalityStat.Naive: 0.2, PersonalityStat.Subby: 0.2}) + subInfo.fetishScore({Fetish.DrugUse: 1.0})
 		if(!getSub().isBlindfolded()):
-			theScore = (max(0.0, theScore) + drugInfo["scoreSubScore"]) * subInfo.getComplyScore()
+			theObeyScore = (max(0.0, theObeyScore) + drugInfo["scoreSubScore"]) * subInfo.getComplyScore()
+		if(subInfo.shouldFullyObey()):
+			theObeyScore = 10000.0
+		var theResistScore:float = 1.0 - clamp(theObeyScore, 0.0, 1.0)
 		actions.append({
 				"id": "eatit",
-				"score": theScore,
+				"score": theObeyScore,
 				"name": "Take pill",
 				"desc": "Eat the offered pill",
 			})
 		actions.append({
 				"id": "noteatit",
-				"score": 1.0 - clamp(theScore, 0.0, 1.0),
+				"score": theResistScore,
 				"name": "Decline pill",
 				"desc": "You don't wanna eat that pill",
 			})
 	if(state == "forcing" && getSexType() != SexType.SlutwallSex):
-		var theresistScore = 0.1 + subInfo.getResistScore()*(0.2 - subInfo.fetishScore({Fetish.DrugUse: 1.0}))
+		var theResistScore:float = 0.1 + subInfo.getResistScore()*(0.2 - subInfo.fetishScore({Fetish.DrugUse: 1.0}))
+		var theObeyScore:float = 1.0 - clamp(theResistScore, 0.0, 1.0)
+		if(subInfo.shouldFullyObey()):
+			theResistScore = 0.0
+			theObeyScore = 10000.0
 		actions.append({
 				"id": "swallowforced",
-				"score": (1.0 - theresistScore),
+				"score": theObeyScore,
 				"name": "Swallow pill",
 				"desc": "Swallow the pill in your mouth",
 			})
 		actions.append({
 				"id": "spitpillout",
-				"score": theresistScore,
+				"score": theResistScore,
 				"name": "Spit pill out",
 				"desc": "You really don't wanna swallow that",
 				"chance": getSubSpitOutChance(100.0, 60.0),


### PR DESCRIPTION
this was part of #174 PR but this implementation is less hacky

"OBEY" will now accept/swallow pill (with ~99.9% chance if other actions are present). i didn't want to mess with "priority" and SexEngine doesn't filter unlikely actions the way InteractionSystem does, hence a silly number of 10000.0 score. feel free to adjust

without this change "OBEY"ing pc would pick unrelated actions like rubbing, ignoring the pill

"OBEY"ing pc would also refuse or spit pill out if they hate drugs:
\- when forcedObedience isn't high enough for pc to have all fetishes as Loves but "OBEY" appeared as result of RNG
\- or when being \*forced\* a drug, where spitting pill out has base score of 0.1

https://github.com/Alexofp/BDCC/blob/924c60c250b22c9cdba7884af8f3ad7f032a67a6/Game/SexEngine/SexActivity/DomDrugUse.gd#L403

don't know if i'll ever get used to reading those lines \~w\~

that one might need rewrite as resisting drug lover has -0.7 resist score but obedient drug lover has 0.1 resist score

\-

i'll try to be slower with pull requests now \~w\~ most of the things i wanted to help improve should be already part of the game, there might be another smol thing or two at some point