### PR TITLE
restraintkey loot list

### DIFF
--- a/Inventory/LootLists/RestraintKeyList.gd
+++ b/Inventory/LootLists/RestraintKeyList.gd
@@ -21,7 +21,7 @@ func getLoot(_id, _characterID, _battleName):
 		chanceMod *= 0.3
 	
 	return [
-		[75.0*chanceMod, [["restraintkey", 1, 1]]],
-		[50.0*chanceMod, [["restraintkey", 1, 2]]],
-		[10.0*chanceMod, [["restraintkey", 3, 5]]],
+		[75.0*chanceMod, [["restraintkey", 1]]],
+		[50.0*chanceMod, [["restraintkey", 1]]],
+		[10.0*chanceMod, [["restraintkey", 3]]],
 	]


### PR DESCRIPTION
should the loot table look closer to this, or is it intended that you can get up to 8 restraint keys if you simultaneously succeed the 75%, 50% and 10% RNG checks?

this is most noticeable when looting junkieStash and your character barely carries any keys, so sometimes you get A LOT of keys and i wonder if that's by design