### PR TITLE
fix: When autoTranslation function is enable, the translator order should show items immediately

### DIFF
--- a/UI/AutoTranslatorMenu/AutoTranslatorMenu.gd
+++ b/UI/AutoTranslatorMenu/AutoTranslatorMenu.gd
@@ -4,6 +4,8 @@ signal onClosePressed
 onready var langList = $VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer2/LanguageList
 onready var translatorsList = $VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer6/TranslatorsList
 func _ready():
+	AutoTranslation.connect("translator_recreated", self, "_on_AutoTranslation_translator_recreated")
+	
 	var allLangs = TranslationLanguage.getAll()
 	var _i = 0
 	for langID in allLangs:
@@ -12,15 +14,21 @@ func _ready():
 			langList.select(_i)
 		_i += 1
 	
-	translatorsList.clearTranslators()
-	_i = 0
-	for translator in AutoTranslation.translators:
-		translatorsList.addTranslator(translator.getName())
-		_i += 1
+	refreshTranslatorOrder()
 
 	$VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer/EnableTranslationBox.pressed = AutoTranslation.shouldTranslate()
 	$VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer3/EnableManualTranslateButton.pressed = AutoTranslation.shouldHaveManualTranslateButton()
 	$VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer4/TranslateButtonsButton.pressed = AutoTranslation.shouldTranslateButtons
+
+func _on_AutoTranslation_translator_recreated():
+	refreshTranslatorOrder()
+
+func refreshTranslatorOrder():
+	translatorsList.clearTranslators()
+	var _i = 0
+	for translator in AutoTranslation.translators:
+		translatorsList.addTranslator(translator.getName())
+		_i += 1
 
 func _on_CloseButton_pressed():
 	AutoTranslation.saveToFile()

--- a/Util/AutoTranslation/AutoTranslation.gd
+++ b/Util/AutoTranslation/AutoTranslation.gd
@@ -1,5 +1,7 @@
 extends Node
 
+signal translator_recreated
+
 var targetLanguage = "de"
 var shouldBeTranslating = false
 var manualTranslateButton = false
@@ -79,6 +81,8 @@ func recreateTranslatorIfNeeded():
 				continue
 			add_child(newTranslator)
 			translators.append(newTranslator)
+	
+	emit_signal("translator_recreated")
 
 func shouldTranslate():
 	return shouldBeTranslating


### PR DESCRIPTION
Previous:
  if the autoTranslation function is disabled at first, the translator order list will show nothing even though you enable it.

After:
  Translator order list will show contents properly.