### PR TITLE
Fix present-flirt failing too often, add text lines which may reveal interests

### DIFF
--- a/Game/InteractionSystem/CharacterPawn.gd
+++ b/Game/InteractionSystem/CharacterPawn.gd
@@ -530,13 +530,31 @@ func getHowMuchLikesPawn(otherPawn, isClamped:bool = false) -> float:
 	
 	return lust.getOverallLikeness(otherPawn.getChar(), isClamped)
 
-func getFocussedLikeness(otherPawn, _focus, isClamped:bool = false) -> float:
+func getFocusedLikeness(otherPawn, _focus, isClamped:bool = false) -> float:
 	var theChar:BaseCharacter = getChar()
 	if(theChar == null || otherPawn == null):
 		return 0.0
 	var lust:LustInterests = theChar.getLustInterests()
 	
 	return lust.getFocussedLikeness(otherPawn.getChar(), _focus, isClamped)
+
+func getFocussedLikeness(otherPawn, _focus, isClamped:bool = false) -> float:
+	return getFocusedLikeness(otherPawn, _focus, isClamped)
+
+func getFocusedLikenessSummary(otherPawn, _focus, isClamped:bool = false) -> Dictionary:
+	var summaryDict:Dictionary = {
+		"resultValue": 0.0,
+		"topicsLikedPresence": [],
+		"topicsLikedAbsence": [],
+		"topicsDislikedPresence": [],
+		"topicsDislikedAbsence": [],
+	}
+	var theChar:BaseCharacter = getChar()
+	if(theChar == null || otherPawn == null):
+		return summaryDict
+	var lust:LustInterests = theChar.getLustInterests()
+	
+	return lust.getFocusedLikenessSummary(otherPawn.getChar(), _focus, isClamped)
 	
 func canSocial() -> bool:
 	return social >= 0.1 || isPlayer()

--- a/Game/InteractionSystem/Interactions/Talking.gd
+++ b/Game/InteractionSystem/Interactions/Talking.gd
@@ -286,15 +286,20 @@ func flirt_flirted_do(_id:String, _args:Dictionary, _context:Dictionary):
 
 
 func flirt_reacted_text():
-	var answer = lust["answer"] if lust.has("answer") else "accept"
-	var likeness = lust["likeness"] if lust.has("likeness") else 1.0
+	var answer:String = lust["answer"] if lust.has("answer") else "accept"
+	var likeness:float = lust["likeness"] if lust.has("likeness") else 1.0
+	var text:String = lust["text"] if lust.has("text") else ""
+	var hasLearnedAnyLustInterests:bool = lust["hasLearnedAnyLustInterests"] if lust.has("hasLearnedAnyLustInterests") else false
 	if(answer == "accept"):
 		sayLine("reacter", "TalkFlirtAccept", {main="reacter", target="starter"})
 	else:
 		gotDenied = true
 		sayLine("reacter", "TalkFlirtDeny", {main="reacter", target="starter"})
 	if(getRolePawn("starter").isPlayer()):
-		saynn("You get a feeling that your flirt was "+str(Util.roundF(likeness*100.0, 1))+"% successful.."+lust["reason"]+"")
+		if(text != ""):
+			saynn(text+" ("+str(Util.roundF(likeness*100.0, 1))+"% success rate)")
+		if(hasLearnedAnyLustInterests == true):
+			addMessage("You learned something new about {reacter.nameS} likes and dislikes..")
 
 	addAction("continue", "Continue", "See what happens next..", "default", 1.0, 60, {})
 

--- a/Game/InteractionSystem/PawnInteractionBase.gd
+++ b/Game/InteractionSystem/PawnInteractionBase.gd
@@ -1401,23 +1401,19 @@ func addReactToLustFocusButtons(actionID:String, lustEntry:Dictionary):
 	var role1pawn = getRolePawn(_role1)
 	var role2pawn = getRolePawn(_role2)
 	
-	var likeness:float = role2pawn.getFocussedLikeness(role1pawn, focus, true)
+	var focusedLikenessSummary:Dictionary = role2pawn.getFocusedLikenessSummary(role1pawn, focus, true)
+	
+	var likeness:float = focusedLikenessSummary["resultValue"]
 	
 	var affection:float = scoreAffection(_role2, _role1)
 	var lust:float = scoreLust(_role2, _role1)
 	var naive:float = scorePersonality(_role2, {PersonalityStat.Naive: 1.0})
 	if(affection < (0.5 - 0.45 * naive)):
 		likeness *= max(affection, lust)
-		lustEntry["reason"] = " (affection is too low)"
-	else:
-		if(likeness <= 0.6):
-			lustEntry["reason"] = " (didn't like the sight)"
-		else:
-			lustEntry["reason"] = ""
-	
+		lustEntry["affectionTooLow"] = true
+
 	if(role2pawn.isPlayer()):
 		likeness = 1.0
-		lustEntry["reason"] = ""
 	
 	#print("LIKENESS: ",likeness)
 	
@@ -1443,7 +1439,7 @@ func reactToLustFocus(args:Dictionary, lustEntry:Dictionary):
 	lustEntry["answer"] = answer
 	lustEntry["likeness"] = likeness
 
-	#var focus = lustEntry["focus"]
+	var focus = lustEntry["focus"]
 	var _role1:String = lustEntry["role1"]
 	var _role2:String = lustEntry["role2"]
 	
@@ -1451,7 +1447,134 @@ func reactToLustFocus(args:Dictionary, lustEntry:Dictionary):
 	var role2pawn = getRolePawn(_role2)
 	role1pawn.afterSocialInteraction()
 	role2pawn.afterSocialInteraction()
-	
+
+	var focusedLikenessSummary:Dictionary = role2pawn.getFocusedLikenessSummary(role1pawn, focus, true)
+	var affectionBeforeChange:float = scoreAffection(_role2, _role1)
+
+	if(likeness > 0.6 && (answer == "accept") && RNG.chance(50)):
+		lustEntry["text"] = ""
+	elif( lustEntry.has("affectionTooLow") && lustEntry["affectionTooLow"] == true && (answer == "deny") ):
+		if(affectionBeforeChange < -0.2):
+			lustEntry["text"] = RNG.pick([
+				"They.. don't really like you in general.",
+			])
+		else:
+			lustEntry["text"] = RNG.pick([
+				"You're too much of a stranger to them.",
+				"This is too sudden. Perhaps it's worth exchanging a word or two.",
+				"They barely know you. It's unlikely they'll openly admit anything to you.",
+			])
+	else:
+		var role2char:BaseCharacter = role2pawn.getChar()
+		var role2lustInterests:LustInterests
+
+		if(role2char != null):
+			role2lustInterests = role2char.getLustInterests()
+
+		var likedWhat:String = ""
+		var likedWhatIsPlural:bool = false
+		var dislikedWhat:String = ""
+		var dislikedWhatIsPlural:bool = false
+		var hasLearnedAnyLustInterests:bool = false
+
+		var role1perceptionScore = max( role1pawn.scorePersonalityMax({PersonalityStat.Naive: -1.0}), 0.0 )
+
+		var shouldRevealWhatWasLiked:bool = RNG.chance(35.0 + 15.0 * role1perceptionScore)
+		var shouldRevealWhatWasDisliked:bool = RNG.chance(35.0 + 15.0 * role1perceptionScore)
+
+		if(shouldRevealWhatWasLiked == true):
+			var suffixesOrdered:Array = ["Presence", "Absence"]
+			if(RNG.chance(20)):
+				suffixesOrdered.invert()
+			for summaryKeySuffix in suffixesOrdered:
+				var summaryKey:String = "topicsLiked" + summaryKeySuffix
+				if( focusedLikenessSummary[summaryKey].size() > 0 ):
+					var topicID = RNG.pick( focusedLikenessSummary[summaryKey] )
+					var topicGroup:TopicBase = GlobalRegistry.getLustTopic(topicID)
+					if(!topicGroup):
+						continue
+					likedWhat = topicGroup.getVisibleName(topicID)
+					if(summaryKeySuffix == "Absence"):
+						likedWhat = "the lack of "+likedWhat
+						likedWhatIsPlural = false
+					else:
+						likedWhatIsPlural = topicGroup.shouldUseAre(topicID)
+					if(role1pawn.isPlayer() && (role2lustInterests != null) && role2lustInterests.learnRandomInterestFromList([topicID])):
+						hasLearnedAnyLustInterests = true
+					break
+
+		if(shouldRevealWhatWasDisliked == true):
+			var suffixesOrdered:Array = ["Presence", "Absence"]
+			if(RNG.chance(20)):
+				suffixesOrdered.invert()
+			for summaryKeySuffix in suffixesOrdered:
+				var summaryKey:String = "topicsDisliked" + summaryKeySuffix
+				if( focusedLikenessSummary[summaryKey].size() > 0 ):
+					var topicID = RNG.pick( focusedLikenessSummary[summaryKey] )
+					var topicGroup:TopicBase = GlobalRegistry.getLustTopic(topicID)
+					if(!topicGroup):
+						continue
+					dislikedWhat = topicGroup.getVisibleName(topicID)
+					if(summaryKeySuffix == "Absence"):
+						dislikedWhat = "the lack of "+dislikedWhat
+						dislikedWhatIsPlural = false
+					else:
+						dislikedWhatIsPlural = topicGroup.shouldUseAre(topicID)
+					if(role1pawn.isPlayer() && (role2lustInterests != null) && role2lustInterests.learnRandomInterestFromList([topicID])):
+						hasLearnedAnyLustInterests = true
+					break
+
+		var LikedWhat:String = Util.capitalizeFirstLetter(likedWhat)
+		var DislikedWhat:String = Util.capitalizeFirstLetter(dislikedWhat)
+
+		if(likedWhat != ""):
+			lustEntry["text"] = RNG.pick([
+				"They seemed to like "+likedWhat,
+				"They seemed fond of "+likedWhat,
+				"They really appreciate "+likedWhat,
+				"They loved "+likedWhat,
+				LikedWhat+" really "+RNG.pick(["drew", "captured"])+" their attention",
+				LikedWhat+" "+("seem" if(likedWhatIsPlural) else "seems")+" to catch their attention pretty well",
+			])
+
+		if(dislikedWhat != ""):
+			if(likedWhat != ""):
+				lustEntry["text"] += RNG.pick([
+					", but they aren't really liking "+dislikedWhat,
+					", though "+dislikedWhat+" "+("aren't" if(dislikedWhatIsPlural) else "isn't")+" really appealing to them",
+					", however "+dislikedWhat+" "+("seem" if(dislikedWhatIsPlural) else "seems")+" to turn them off",
+				])
+			else:
+				lustEntry["text"] = RNG.pick([
+					"You noticed they aren't really into "+dislikedWhat,
+					"You were able to notice their aversion to "+dislikedWhat,
+					DislikedWhat+" "+("don't" if(dislikedWhatIsPlural) else "doesn't")+" seem to interest them",
+					DislikedWhat+" "+("are" if(dislikedWhatIsPlural) else "is")+" a bit outside their interests",
+				])
+		else:
+			if(likedWhat != "" && answer == "deny"):
+				lustEntry["text"] += RNG.pick([
+					", but unfortunately that wasn't enough",
+					", but that didn't seem enough",
+					", however something still seemed to turn them off",
+					", though they're still seemingly unhappy about something",
+				])
+
+		if(likedWhat != "" || dislikedWhat != ""):
+			lustEntry["text"] += "."
+		else:
+			if(answer == "accept"):
+				lustEntry["text"] = ""
+			else:
+				lustEntry["text"] = RNG.pick([
+					"It was difficult to tell what displeased them.",
+					"You were sure this was going to work..",
+					"Is there something wrong with their taste?..",
+				])
+
+		if(hasLearnedAnyLustInterests == true):
+			lustEntry["hasLearnedAnyLustInterests"] = true
+
 	if(answer == "accept"):
 		affectLust(_role2, _role1, max(likeness, 0.1) * 0.3)
 	elif(answer == "deny"):

--- a/Game/LustCombat/LustInterests.gd
+++ b/Game/LustCombat/LustInterests.gd
@@ -111,10 +111,12 @@ func getFocusedLikenessSummary(_pc, _focus, isClamped:bool = false) -> Dictionar
 		var playerValue:float = topicGroup.getTopicValue(topicID, _pc) # 0 to 1
 
 		var addsToFocus:float = topicGroup.getAddsToFocus(topicID, _focus)
-		var interestImportanceWithFocus:float = abs(loveValue * addsToFocus)
+		var interestImportance:float = abs(loveValue)
+		var interestImportanceWithFocus:float = (interestImportance * addsToFocus)
 
 		var goodMatchRatio:float = 1.0 - min(abs(loveValueRatio - playerValue), 1.0)
-		var goodMatchRatioWithFocus:float = (goodMatchRatio * addsToFocus)
+
+		var interestImportanceWithFocusMatched:float = (interestImportanceWithFocus * goodMatchRatio)
 
 		if(interestImportanceWithFocus >= 0.5 && (playerValue < 0.3 || playerValue > 0.7)):
 			var summaryKeySuffix:String = "Presence" if(playerValue > 0.5) else "Absence"
@@ -123,8 +125,8 @@ func getFocusedLikenessSummary(_pc, _focus, isClamped:bool = false) -> Dictionar
 			elif(goodMatchRatio < 0.3):
 				summaryDict["topicsDisliked" + summaryKeySuffix].append(topicID)
 
+		resultValue += interestImportanceWithFocusMatched
 		maxPossible += interestImportanceWithFocus
-		resultValue += goodMatchRatioWithFocus
 
 	if(isClamped):
 		if(maxPossible <= 0.0):

--- a/Game/LustCombat/LustInterests.gd
+++ b/Game/LustCombat/LustInterests.gd
@@ -89,28 +89,59 @@ func getOverallLikeness(_pc, isClamped:bool = false) -> float:
 		return clamp(resultValue / maxPossble, 0.0, 1.0)
 	return resultValue
 
-func getFocussedLikeness(_pc, _focus, isClamped:bool = false) -> float:
+func getFocusedLikenessSummary(_pc, _focus, isClamped:bool = false) -> Dictionary:
+	var summaryDict:Dictionary = {
+		"resultValue": 0.0,
+		"topicsLikedPresence": [],
+		"topicsLikedAbsence": [],
+		"topicsDislikedPresence": [],
+		"topicsDislikedAbsence": [],
+	}
+
 	var resultValue:float = 0.0
-	var maxPossble:float = 0.0
-	
+	var maxPossible:float = 0.0
+
 	for topicID in interests:
 		var topicGroup: TopicBase = GlobalRegistry.getLustTopic(topicID)
 		if(!topicGroup):
 			continue
-		var loveValue:float = Interest.getValue(interests[topicID])
-		
-		var playerValue:float = topicGroup.getTopicValue(topicID, _pc)
-		
-		var addValue:float = loveValue * topicGroup.getAddsToFocus(topicID, _focus)
-		
-		maxPossble += abs(addValue)
-		resultValue += addValue * playerValue
-	
+		var loveValue:float = Interest.getValue(interests[topicID]) # -2 to 1
+		var loveValueRatio:float = clamp((loveValue + 1.0) / 2.0, 0.0, 1.0)
+
+		var playerValue:float = topicGroup.getTopicValue(topicID, _pc) # 0 to 1
+
+		var addsToFocus:float = topicGroup.getAddsToFocus(topicID, _focus)
+		var interestImportanceWithFocus:float = abs(loveValue * addsToFocus)
+
+		var goodMatchRatio:float = 1.0 - min(abs(loveValueRatio - playerValue), 1.0)
+		var goodMatchRatioWithFocus:float = (goodMatchRatio * addsToFocus)
+
+		if(interestImportanceWithFocus >= 0.5 && (playerValue < 0.3 || playerValue > 0.7)):
+			var summaryKeySuffix:String = "Presence" if(playerValue > 0.5) else "Absence"
+			if(goodMatchRatio >= 0.7):
+				summaryDict["topicsLiked" + summaryKeySuffix].append(topicID)
+			elif(goodMatchRatio < 0.3):
+				summaryDict["topicsDisliked" + summaryKeySuffix].append(topicID)
+
+		maxPossible += interestImportanceWithFocus
+		resultValue += goodMatchRatioWithFocus
+
 	if(isClamped):
-		if(maxPossble <= 0.0):
-			return 0.0
-		return clamp(resultValue / maxPossble, 0.0, 1.0)
-	return resultValue
+		if(maxPossible <= 0.0):
+			resultValue = 0.0
+		else:
+			resultValue = clamp(resultValue / maxPossible, 0.0, 1.0)
+
+	summaryDict["resultValue"] = resultValue
+
+	return summaryDict
+
+func getFocusedLikeness(_pc, _focus, isClamped:bool = false) -> float:
+	var summaryDict:Dictionary = getFocusedLikenessSummary(_pc, _focus, isClamped)
+	return summaryDict["resultValue"]
+
+func getFocussedLikeness(_pc, _focus, isClamped:bool = false) -> float:
+	return getFocusedLikeness(_pc, _focus, isClamped)
 
 func reactLustAction(_pc, _actionInterests, _maxUnlocks = 1):
 	var resultValue = 0.0


### PR DESCRIPTION
flirt by presenting body/bodypart practically never worked for me (which i think happens from negative values, abs of `Interest.Hates` would add 2 to divisor, abs of `Interest.Dislikes` would add 1 to divisor, even if player didnt have that trait they'd end up at 0 out of 2, at best)

i also wanted it to actually tell why it didn't succeed, at least sometimes. it reveals preferences in the process, but i think's fair since failed flirts make lust/affection go down by quite a bit

overall it looks like this

![An androgynous body really drew their attention, though they're still seemingly unhappy about something. (57.8% success rate)](https://github.com/user-attachments/assets/b9f87781-e5b9-4a37-a5c1-d3e03fce959c)

![You were able to notice their aversion to any used hole. (58.7% success rate). You learned something new about their likes and dislikes..](https://github.com/user-attachments/assets/0cbf2fd8-7de9-450c-954c-7004ff37ef7e)
