### PR TITLE
Workaround rare crash for sex aftermath outside the editor

### DIFF
--- a/Game/InteractionSystem/PawnInteractionBase.gd
+++ b/Game/InteractionSystem/PawnInteractionBase.gd
@@ -823,7 +823,7 @@ func doFightAftermath(_fightersData, newResult):
 func doSexAftermath(_sexData, theSexResult:SexEngineResult):
 	var domPawn = getRolePawn(_sexData[0])
 	var subPawn = getRolePawn(_sexData[1])
-	var sexType = (_sexData[2] if _sexData.size() > 2 else SexType.DefaultSex)
+	var sexType = (_sexData[2] if _sexData.size() > 2 else theSexResult.sexTypeID)
 	
 	if(domPawn != null):
 		domPawn.afterSex(true)
@@ -986,7 +986,14 @@ func getDebugInfo():
 func receiveSexEngineResult(_result:SexEngineResult):
 	isWaitingScene = false
 	sexResult = _result
-	doSexAftermath(currentActionArgs["sex"], sexResult)
+	if(currentActionArgs.has("sex")):
+		doSexAftermath(currentActionArgs["sex"], sexResult)
+	else:
+		assert(false, "FIX ME")
+		# Try to recover sex aftermath data outside the editor
+		var derivedSexData = sexResult.tryDeriveSexData()
+		if(derivedSexData != null):
+			doSexAftermath(derivedSexData, sexResult)
 	doCurrentAction()
 
 func receiveSceneStatusFinal(_result:Dictionary):

--- a/Game/SexEngine/SexEngine.gd
+++ b/Game/SexEngine/SexEngine.gd
@@ -101,6 +101,9 @@ func initSexType(theSexType, args:Dictionary = {}):
 	if(sexType != null):
 		sexType.setSexEngine(self)
 		sexType.initArgs(args)
+		sexResult.sexTypeID = sexType.id
+	else:
+		sexResult.sexTypeID = SexType.DefaultSex
 
 func getSexTypeID() -> String:
 	if(sexType == null):
@@ -352,6 +355,7 @@ func checkIfDomsNeedMoreGoals():
 
 func doFastSex() -> SexEngineResult:
 	var newResult:SexEngineResult = SexEngineResult.new()
+	newResult.sexTypeID = getSexTypeID()
 	
 	for subID in subs:
 		GM.main.updateCharacterUntilNow(subID)
@@ -1124,6 +1128,7 @@ func endSex():
 	if(sexEnded):
 		return
 	sexResult.clear()
+	sexResult.sexTypeID = getSexTypeID()
 	sexResult.subsWon = true
 	for domID in doms:
 		var domInfo = doms[domID]

--- a/Game/SexEngine/Util/SexEngineResult.gd
+++ b/Game/SexEngine/Util/SexEngineResult.gd
@@ -1,11 +1,13 @@
 extends Reference
 class_name SexEngineResult
 
+var sexTypeID:String = SexType.DefaultSex
 var doms:Dictionary = {}
 var subs:Dictionary = {}
 var subsWon:bool = false
 
 func clear():
+	sexTypeID = SexType.DefaultSex
 	doms.clear()
 	subs.clear()
 	subsWon = false
@@ -112,12 +114,14 @@ func saveData() -> Dictionary:
 		subsData[subID] = subs[subID].saveData()
 	
 	return {
+		sexTypeID = sexTypeID,
 		doms = domsData,
 		subs = subsData,
 		subsWon = subsWon,
 	}
 
 func loadData(_data:Dictionary):
+	sexTypeID = SAVE.loadVar(_data, "sexTypeID", SexType.DefaultSex)
 	subsWon = SAVE.loadVar(_data, "subsWon", false)
 	var domsData:Dictionary = SAVE.loadVar(_data, "doms", {})
 	var subsData:Dictionary = SAVE.loadVar(_data, "subs", {})
@@ -135,3 +139,9 @@ func loadData(_data:Dictionary):
 		newSubResult.id = subID
 		newSubResult.loadData(SAVE.loadVar(subsData, subID, {}))
 		subs[subID] = newSubResult
+
+func tryDeriveSexData():
+	if (doms.size() != 1 || subs.size() != 1):
+		# Can't derive from unusual parameters
+		return null
+	return [doms.keys()[0], subs.keys()[0], sexTypeID]


### PR DESCRIPTION
Attempt at making #200 no longer crash the game outside the editor.

Also add a `SexEngineResult.sexTypeID` field.