### PR TITLE
Replace unknown bodyparts IDs when loading a save

### DIFF
--- a/Characters/Dynamic/DynamicCharacter.gd
+++ b/Characters/Dynamic/DynamicCharacter.gd
@@ -487,7 +487,7 @@ func loadData(data):
 		var id = SAVE.loadVar(loadedBodyparts[slot], "id", "errorbad")
 		var bodypart = GlobalRegistry.createBodypart(id)
 		if(bodypart == null):
-			var replacementID = BodypartSlot.findReplacement(slot, id)
+			var replacementID = BodypartSlot.findReplacement(slot, id, npcSpecies, getGender())
 			if(replacementID == null || replacementID == ""):
 				Log.printerr("Couldn't find an replacement bodypart for slot "+str(slot))
 				continue
@@ -649,7 +649,7 @@ func loadFromDatapackCharacter(_datapack:Datapack, _datapackChar:DatapackCharact
 		var id = SAVE.loadVar(loadedBodyparts[slot], "id", "errorbad")
 		var bodypart = GlobalRegistry.createBodypart(id)
 		if(bodypart == null):
-			var replacementID = BodypartSlot.findReplacement(slot, id)
+			var replacementID = BodypartSlot.findReplacement(slot, id, npcSpecies, getGender())
 			if(replacementID == null || replacementID == ""):
 				Log.printerr("Couldn't find an replacement bodypart for slot "+str(slot))
 				continue

--- a/Player/Bodyparts/BodypartSlot.gd
+++ b/Player/Bodyparts/BodypartSlot.gd
@@ -112,16 +112,38 @@ static func isEssential(slot):
 	
 	return true
 
-static func findReplacement(slot, oldvalue):
-	if(slot == Body):
-		return "anthrobody"
-	if(slot == Arms):
-		return "anthroarms"
+# Note: we assume "oldvalue" does not exists as a bodypart ref.
+static func findReplacement(slot, oldvalue, species=null, gender=Gender.Androgynous):
+	# Hardcoded known good convertions
 	if(slot == Legs):
-		if(oldvalue in ["felineleg", "canineleg", "dragonleg"]):
+		if(oldvalue in ["flufflegs", "felineleg", "canineleg", "dragonleg"]):
 			return "digilegs"
 		if(oldvalue in ["humanleg"]):
 			return "plantilegs"
+	elif(slot == Body):
+		if(oldvalue in ["fluffbody"]):
+			return "anthrobody"
+	# Get default bodypart from species
+	var mainSpecies = null
+	if(species != null):
+		for speciesItr in species:
+			mainSpecies = GlobalRegistry.getSpecies(speciesItr)
+			if mainSpecies != null:
+				break
+	if(mainSpecies == null):
+		mainSpecies = GlobalRegistry.getSpecies("canine")
+	var replacmentIdFor = mainSpecies.getDefaultForSlot(slot, gender)
+	if(replacmentIdFor != null && GlobalRegistry.getBodypartRef(replacmentIdFor) != null):
+		return replacmentIdFor
+	# Hardcoded fallback convertions
+	if(slot == Body):
+		return "anthrobody"
+	elif(slot == Arms):
+		return "anthroarms"
+	elif(slot == Anus):
+		return "anus"
+	elif(slot == Legs):
 		return "plantilegs"
-	
+	elif(slot == Vagina):
+		return "vagina"
 	return null

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -462,7 +462,7 @@ func loadData(data):
 		var id = SAVE.loadVar(loadedBodyparts[slot], "id", "errorbad")
 		var bodypart = GlobalRegistry.createBodypart(id)
 		if(bodypart == null):
-			var replacementID = BodypartSlot.findReplacement(slot, id)
+			var replacementID = BodypartSlot.findReplacement(slot, id, pickedSpecies, getGender())
 			if(replacementID == null || replacementID == ""):
 				Log.printerr("Couldn't find an replacement bodypart for slot "+str(slot))
 				continue


### PR DESCRIPTION
Works perfectly fine on my custom save using hypertus a lot on my character.

Added explicit support for the torso and legs of the fluffybodypart mod.

The new parameters on `findReplacement` are optional to not break existing mods.