### PR TITLE
Fix a temporary severe error when loading a save

### DIFF
--- a/Game/SaveManager.gd
+++ b/Game/SaveManager.gd
@@ -164,7 +164,7 @@ func loadGame(_path):
 func switchToGameAndLoad(_path):
 	var _ok = get_tree().change_scene("res://Game/MainScene.tscn")
 	yield(get_tree(),"idle_frame")
-	loadGame(_path)
+	call_deferred("loadGame", _path)
 
 func switchToGameAndResumeLatestSave():
 	var saves: Array = getSavesSortedByDate()
@@ -172,7 +172,7 @@ func switchToGameAndResumeLatestSave():
 		return
 	var _ok = get_tree().change_scene("res://Game/MainScene.tscn")
 	yield(get_tree(),"idle_frame")
-	loadGame(saves[0])
+	call_deferred("loadGame", saves[0])
 
 func getLoadedSavefileVersion():
 	return loadedSavefileVersion


### PR DESCRIPTION
After the recent update, Sometimes when you load a save, the game will crash or just show the start scene. like below (in Chinese sry)

<img width="775" height="98" alt="QQ20250922-002152" src="https://github.com/user-attachments/assets/4a1c4c5a-4feb-478b-aa67-f12d617279fa" />
<img width="1282" height="752" alt="QQ20250922-002206" src="https://github.com/user-attachments/assets/2c84ddbb-2773-4a8c-82d5-54280c8da82a" />

This will happen because when you load a save, the game needs to change to the MainScene, while godot will only load the Node at the next idle frame, so `yield(get_tree(),"idle_frame")` is nessacery. But in the next idle frame, the node loading processes goes with the function `loadGame`. If you are not lucky enough, the `loadGame` will hit `GM.main` first, before the `MainScene` node is fully loaded.

So I used `call_deferred` to trigger the `loadGame` at the end of the frame, which may fix the problem.

For other solution, like using Signal, you can try it if you like. 