### PR TITLE
fix #313 Eliza Quinn interaction 'Milking' does not re-equip bra afterwards

### DIFF
--- a/Inventory/Inventory.gd
+++ b/Inventory/Inventory.gd
@@ -340,8 +340,11 @@ func forceEquipRemoveOther(item) -> bool:
 	
 	return equipItem(item)
 
-func forceEquipRemoveOtherIfExists(item: ItemBase) -> bool:
-	return forceEquipRemoveOther(item) if item else false
+func forceEquipReturnOther(item: ItemBase):
+	var slot: String = item.getClothingSlot()
+	var displacedItem = removeItemFromSlot(slot)
+	equipItem(item)
+	return displacedItem
 
 func forceEquipStoreOther(item):
 	var slot:String = item.getClothingSlot()

--- a/Inventory/Inventory.gd
+++ b/Inventory/Inventory.gd
@@ -267,7 +267,7 @@ func getCharacter():
 		return get_parent()
 	return null
 		
-func equipItem(item):
+func equipItem(item) -> bool:
 	if(hasItem(item)):
 		removeItem(item)
 	
@@ -332,13 +332,16 @@ func unequipSlotRemoveIfRestraint(slot):
 		addItem(theitem)
 		return true
 
-func forceEquipRemoveOther(item):
+func forceEquipRemoveOther(item) -> bool:
 	var slot:String = item.getClothingSlot()
 	
 	if(hasSlotEquipped(slot)):
 		removeItemFromSlot(slot)
 	
 	return equipItem(item)
+
+func forceEquipRemoveOtherIfExists(item: ItemBase) -> bool:
+	return forceEquipRemoveOther(item) if item else false
 
 func forceEquipStoreOther(item):
 	var slot:String = item.getClothingSlot()
@@ -358,7 +361,17 @@ func forceEquipStoreOtherUnlessRestraint(item):
 			addItem(storedItem)
 	
 	return equipItem(item)
-	
+
+func forceEquipStoreOtherUnlessRestraintReturnOther(item: ItemBase):
+	var slot:String = item.getClothingSlot()
+	var storedItem = null
+	if(hasSlotEquipped(slot)):
+		storedItem = removeItemFromSlot(slot)
+		if(!storedItem.isRestraint() || storedItem.isImportant() || storedItem.isRestraintShouldKeep()):
+			addItem(storedItem)
+	equipItem(item)
+	return storedItem
+
 func equipItemBy(item, equipper):
 	var success = equipItem(item)
 	if(success):

--- a/Modules/MedicalModule/Milking/ElizaQuickMilkingScene.gd
+++ b/Modules/MedicalModule/Milking/ElizaQuickMilkingScene.gd
@@ -6,9 +6,7 @@ var vaginaMilked = false
 var hasPenisPump = false
 var amountCollected = 0.0
 
-var displacedItemBreasts: ItemBase = null
-var displacedItemPenis  : ItemBase = null
-var displacedItemVagina : ItemBase = null # Not currently in use because there is no pump item implemented yet. -Zsar 2026-05-14
+var displacedItems := LightInventory.new()
 
 func _init():
 	sceneID = "ElizaQuickMilkingScene"
@@ -23,13 +21,13 @@ func _reactInit():
 			var theFluids = thePump.getFluids()
 			if(theFluids):
 				theFluids.addFluid("Milk", 400.0)
-		displacedItemBreasts = GM.pc.getInventory().forceEquipStoreOtherUnlessRestraintReturnOther(thePump)
+		displacedItems.addItem(GM.pc.getInventory().forceEquipReturnOther(thePump))
 	if(GM.pc.hasReachablePenis() || GM.pc.isWearingChastityCage()):
 		amountCollected += GM.main.SCI.processMilkPlayerPenis()
 		penisMilked = true
 		if(GM.pc.hasReachablePenis() || GM.pc.getWornChastityCage().getRestraintData().canBeEasilyRemovedByDom()):
 			var thePump = GlobalRegistry.createItem("PenisPump")
-			displacedItemPenis = GM.pc.getInventory().forceEquipStoreOtherUnlessRestraintReturnOther(thePump)
+			displacedItems.addItem(GM.pc.getInventory().forceEquipReturnOther(thePump))
 			hasPenisPump = true
 	if(GM.pc.hasReachableVagina()):
 		amountCollected += GM.main.SCI.processMilkPlayerVagina()
@@ -61,9 +59,8 @@ func _react(_action: String, _args) -> void:
 			GM.pc.getInventory().clearSlot(InventorySlot.Penis)
 		if(breastsMilked):
 			GM.pc.getInventory().clearSlot(InventorySlot.UnderwearTop)
-		GM.pc.getInventory().forceEquipRemoveOtherIfExists(displacedItemBreasts)
-		GM.pc.getInventory().forceEquipRemoveOtherIfExists(displacedItemPenis)
-		GM.pc.getInventory().forceEquipRemoveOtherIfExists(displacedItemVagina)
+		for displacedItem in displacedItems.getAllItems():
+			GM.pc.getInventory().forceEquipRemoveOther(displacedItem)
 
 		playAnimation(StageScene.Duo, "stand", {npc="eliza"})
 		aimCameraAndSetLocName(GM.pc.getLocation())
@@ -80,9 +77,7 @@ func saveData():
 	data["vaginaMilked"] = vaginaMilked
 	data["hasPenisPump"] = hasPenisPump
 	data["amountCollected"] = amountCollected
-	data["displacedItemBreasts"] = displacedItemBreasts.uniqueID if displacedItemBreasts else null
-	data["displacedItemPenis"]   = displacedItemPenis  .uniqueID if displacedItemPenis   else null
-	data["displacedItemVagina"]  = displacedItemVagina .uniqueID if displacedItemVagina  else null
+	data["displacedItems"] = displacedItems.saveData()
 
 	return data
 
@@ -94,9 +89,4 @@ func loadData(data):
 	vaginaMilked = SAVE.loadVar(data, "vaginaMilked", false)
 	hasPenisPump = SAVE.loadVar(data, "hasPenisPump", false)
 	amountCollected = SAVE.loadVar(data, "amountCollected", 0.0)
-	var idDisplacedItemBreasts = SAVE.loadVar(data, "displacedItemBreasts")
-	displacedItemBreasts = GM.pc.getInventory().getItemByUniqueID(idDisplacedItemBreasts) if idDisplacedItemBreasts else null
-	var idDisplacedItemPenis   = SAVE.loadVar(data, "displacedItemPenis")
-	displacedItemPenis   = GM.pc.getInventory().getItemByUniqueID(idDisplacedItemPenis)   if idDisplacedItemPenis   else null
-	var idDisplacedItemVagina  = SAVE.loadVar(data, "displacedItemVagina")
-	displacedItemVagina  = GM.pc.getInventory().getItemByUniqueID(idDisplacedItemVagina)  if idDisplacedItemVagina  else null
+	displacedItems.loadData(SAVE.loadVar(data, "displacedItems", {}))

--- a/Modules/MedicalModule/Milking/ElizaQuickMilkingScene.gd
+++ b/Modules/MedicalModule/Milking/ElizaQuickMilkingScene.gd
@@ -27,10 +27,10 @@ func _reactInit():
 	if(GM.pc.hasReachablePenis() || GM.pc.isWearingChastityCage()):
 		amountCollected += GM.main.SCI.processMilkPlayerPenis()
 		penisMilked = true
-	if(GM.pc.hasReachablePenis()):
-		var thePump = GlobalRegistry.createItem("PenisPump")
-		displacedItemPenis = GM.pc.getInventory().forceEquipStoreOtherUnlessRestraintReturnOther(thePump)
-		hasPenisPump = true
+		if(GM.pc.hasReachablePenis() || GM.pc.getWornChastityCage().getRestraintData().canBeEasilyRemovedByDom()):
+			var thePump = GlobalRegistry.createItem("PenisPump")
+			displacedItemPenis = GM.pc.getInventory().forceEquipStoreOtherUnlessRestraintReturnOther(thePump)
+			hasPenisPump = true
 	if(GM.pc.hasReachableVagina()):
 		amountCollected += GM.main.SCI.processMilkPlayerVagina()
 		vaginaMilked = true

--- a/Modules/MedicalModule/Milking/ElizaQuickMilkingScene.gd
+++ b/Modules/MedicalModule/Milking/ElizaQuickMilkingScene.gd
@@ -6,6 +6,10 @@ var vaginaMilked = false
 var hasPenisPump = false
 var amountCollected = 0.0
 
+var displacedItemBreasts: ItemBase = null
+var displacedItemPenis  : ItemBase = null
+var displacedItemVagina : ItemBase = null # Not currently in use because there is no pump item implemented yet. -Zsar 2026-05-14
+
 func _init():
 	sceneID = "ElizaQuickMilkingScene"
 
@@ -19,13 +23,13 @@ func _reactInit():
 			var theFluids = thePump.getFluids()
 			if(theFluids):
 				theFluids.addFluid("Milk", 400.0)
-		GM.pc.getInventory().forceEquipStoreOtherUnlessRestraint(thePump)
+		displacedItemBreasts = GM.pc.getInventory().forceEquipStoreOtherUnlessRestraintReturnOther(thePump)
 	if(GM.pc.hasReachablePenis() || GM.pc.isWearingChastityCage()):
 		amountCollected += GM.main.SCI.processMilkPlayerPenis()
 		penisMilked = true
 	if(GM.pc.hasReachablePenis()):
 		var thePump = GlobalRegistry.createItem("PenisPump")
-		GM.pc.getInventory().forceEquipStoreOtherUnlessRestraint(thePump)
+		displacedItemPenis = GM.pc.getInventory().forceEquipStoreOtherUnlessRestraintReturnOther(thePump)
 		hasPenisPump = true
 	if(GM.pc.hasReachableVagina()):
 		amountCollected += GM.main.SCI.processMilkPlayerVagina()
@@ -47,7 +51,7 @@ func _run():
 
 		addButton("Continue", "See what happens next", "endthescene_removestuff")
 
-func _react(_action: String, _args):
+func _react(_action: String, _args) -> void:
 	if(_action == "endthescene"):
 		endScene()
 		return
@@ -57,7 +61,10 @@ func _react(_action: String, _args):
 			GM.pc.getInventory().clearSlot(InventorySlot.Penis)
 		if(breastsMilked):
 			GM.pc.getInventory().clearSlot(InventorySlot.UnderwearTop)
-		
+		GM.pc.getInventory().forceEquipRemoveOtherIfExists(displacedItemBreasts)
+		GM.pc.getInventory().forceEquipRemoveOtherIfExists(displacedItemPenis)
+		GM.pc.getInventory().forceEquipRemoveOtherIfExists(displacedItemVagina)
+
 		playAnimation(StageScene.Duo, "stand", {npc="eliza"})
 		aimCameraAndSetLocName(GM.pc.getLocation())
 		endScene()
@@ -73,6 +80,9 @@ func saveData():
 	data["vaginaMilked"] = vaginaMilked
 	data["hasPenisPump"] = hasPenisPump
 	data["amountCollected"] = amountCollected
+	data["displacedItemBreasts"] = displacedItemBreasts.uniqueID if displacedItemBreasts else null
+	data["displacedItemPenis"]   = displacedItemPenis  .uniqueID if displacedItemPenis   else null
+	data["displacedItemVagina"]  = displacedItemVagina .uniqueID if displacedItemVagina  else null
 
 	return data
 
@@ -84,3 +94,9 @@ func loadData(data):
 	vaginaMilked = SAVE.loadVar(data, "vaginaMilked", false)
 	hasPenisPump = SAVE.loadVar(data, "hasPenisPump", false)
 	amountCollected = SAVE.loadVar(data, "amountCollected", 0.0)
+	var idDisplacedItemBreasts = SAVE.loadVar(data, "displacedItemBreasts")
+	displacedItemBreasts = GM.pc.getInventory().getItemByUniqueID(idDisplacedItemBreasts) if idDisplacedItemBreasts else null
+	var idDisplacedItemPenis   = SAVE.loadVar(data, "displacedItemPenis")
+	displacedItemPenis   = GM.pc.getInventory().getItemByUniqueID(idDisplacedItemPenis)   if idDisplacedItemPenis   else null
+	var idDisplacedItemVagina  = SAVE.loadVar(data, "displacedItemVagina")
+	displacedItemVagina  = GM.pc.getInventory().getItemByUniqueID(idDisplacedItemVagina)  if idDisplacedItemVagina  else null


### PR DESCRIPTION
Implemented a quick-and-dirty fix on just the quick milking scene.

Found that fixing this properly would touch quite a lot of code, so I am asking for directions first.

... Seeing that one would have to retrofit any scene-by-scene with this capability makes me feel a bit nauseous. Even with a dedicated helper class, it would still mean two calls and one variable per scene, which may always be forgotten or otherwise go out of sync between code changes.

Maybe `SceneBase` could get its own inventory handling functions and encapsulate the helper class, such that individual scenes only need to decide whether items _should be_ replaced or not? That way only one call (per item) can be forgotten, the one that stores said item in the first place.