### PR TITLE
fix #303 NPCs locked in Stocks magically restore Stamina to 100% after 'Use'

### DIFF
--- a/Game/BaseCharacter.gd
+++ b/Game/BaseCharacter.gd
@@ -2305,11 +2305,6 @@ func afterSexEnded(sexInfo):
 		if(resultText != null && resultText != ""):
 			GM.main.addMessage(resultText)
 	
-	if(!isPlayer()):
-		addLust(-getLust())
-		addPain(-getPain())
-		addStamina(getMaxStamina())
-
 	consciousness = 1.0
 	arousal = 0.0
 		


### PR DESCRIPTION
fixed for Stocks, TODO:
* ~~deduplicate (or at least fix separately) Slutwall~~ - actually works fine and now I cannot reproduce them ignoring Stamina when I go back to HEAD~1 either...
Guess I can drop 3bc120a263e9105c207f7cd48bb24bae8c65b1f1 then.
* further verify nothing else broke