### PR TITLE
[Fix] Missing Translated Buttons

### DIFF
--- a/Game/UI/GameUI.gd
+++ b/Game/UI/GameUI.gd
@@ -552,8 +552,8 @@ func translateText(manualButton = false):
 		var buttonsTexts = []
 		if(AutoTranslation.shouldTranslateButtons):
 			for optionID in options:
-				buttonsTexts.append(options[optionID][1])
-				buttonsTexts.append(options[optionID][2].replace("\n", "^"))
+				buttonsTexts.append("[[BTN_"+str(optionID)+"_TEXT]]"+options[optionID][1])
+				buttonsTexts.append("[[BTN_"+str(optionID)+"_DESC]]"+options[optionID][2].replace("\n", "^"))
 		
 		translateStatusLabel.text = "Translating.."
 		currentTranslationTask += 1
@@ -576,17 +576,28 @@ func translateText(manualButton = false):
 		if(result != null && result != ""):
 			if(buttonsTexts.size() > 0):
 				var resultSplitted = result.split("\n")
-				if(resultSplitted.size() >= buttonsTexts.size()):
-					var _i = 0
-					for optionID in options:
-						var realI = resultSplitted.size() - buttonsTexts.size() + _i*2
-						options[optionID].append(resultSplitted[realI])
-						options[optionID].append(resultSplitted[realI+1].replace("^", "\n"))
-						
-						_i += 1
-					resultSplitted.resize(resultSplitted.size() - buttonsTexts.size())
-					result = Util.join(resultSplitted, "\n")
-					queueUpdate()
+				var translatedButtons = {}
+				var storyLines = []
+				for line in resultSplitted:
+					if(line.begins_with("[[BTN_") && line.find("]]", 0) != -1):
+						var markerEnd = line.find("]]", 0)
+						var marker = line.substr(2, markerEnd - 2)
+						var translatedText = line.substr(markerEnd + 2, line.length())
+						translatedButtons[marker] = translatedText
+					else:
+						storyLines.append(line)
+				for optionID in options:
+					var textMarker = "BTN_"+str(optionID)+"_TEXT"
+					var descMarker = "BTN_"+str(optionID)+"_DESC"
+					if(translatedButtons.has(textMarker) && translatedButtons.has(descMarker)):
+						if(options[optionID].size() > 5):
+							options[optionID][5] = translatedButtons[textMarker]
+							options[optionID][6] = translatedButtons[descMarker].replace("^", "\n")
+						else:
+							options[optionID].append(translatedButtons[textMarker])
+							options[optionID].append(translatedButtons[descMarker].replace("^", "\n"))
+				result = Util.join(storyLines, "\n")
+				queueUpdate()
 			
 			savedTranslatedText = result
 			if(!showOriginalCheckbox.pressed):


### PR DESCRIPTION
When random "hypnotic" event uppears - translated buttons be gone, ill fix it

No translate:
<img width="1111" height="1052" alt="image" src="https://github.com/user-attachments/assets/fe81aa44-af7f-4ccf-827c-0277a721bf48" />

Auto-translate result (Ru):
<img width="1108" height="1056" alt="image" src="https://github.com/user-attachments/assets/e888a23c-758b-4d19-8b35-cfb9df7cd98d" />
(Buttons silly gone)

### After patch:
<img width="1103" height="1056" alt="image" src="https://github.com/user-attachments/assets/37697368-76b8-4353-927f-9d318e320e64" />
(Buttons now here!)

It might cause problems somewhere else, but I quickly tested the localization outside of this event and everything was stable

UPD: It turned out that this is not the only place where the buttons disappear, so the fix can be considered global