### PR TITLE
add random name generator when starting new game or renaming owned pawns

### DIFF
--- a/Game/NpcSlavery/SlaveActionScenes/ActionSlaveryChangeName.gd
+++ b/Game/NpcSlavery/SlaveActionScenes/ActionSlaveryChangeName.gd
@@ -25,7 +25,7 @@ func _run():
 		saynn("Your slave's current name is {npc.name}.")
 		
 		if(npc.getFlag("OriginalName") != null && npc.getFlag("OriginalName") != npc.getName()):
-			saynn("You recall that {npc.his} original name was "+str(npc.getFlag("OriginalName", "Bob")))
+			saynn("You recall that {npc.his} original name was "+str(npc.getFlag("OriginalName", "Bob"))+".")
 		
 		if(npcSlavery.isMindBroken()):
 			saynn("[say=npc]..kh..[/say]")
@@ -49,7 +49,7 @@ func _run():
 		addButton("Cancel", "You changed your mind", "")
 	
 	if(state == "pick_name"):
-		saynn("Pick a new name for your slave")
+		say("Pick a new name for your slave:")
 		
 		var textBox:LineEdit = addTextbox("npc_name")
 		textBox.text = npc.getName()
@@ -57,6 +57,7 @@ func _run():
 		
 		addButton("Confirm", "Change the name", "do_pick_name")
 		addButton("Cancel", "You changed your mind", "")
+		addButtonAt(4, "Random?", "Help choose a random name", "do_random_name")
 	
 	if(state == "pick_desc"):
 		saynn("Pick a new description for your slave")
@@ -86,9 +87,19 @@ func _react(_action: String, _args):
 		return
 	
 	if(_action == "do_pick_name"):
-		if(setSlaveNameTo(getTextboxData("npc_name"))):
+		var new_name:String = ""
+		if(_args.size() > 0):
+			new_name = _args[0]
+		else:
+			new_name = getTextboxData("npc_name")
+
+		if(setSlaveNameTo(new_name)):
 			addMessage("You changed your slave's name!")
 			setState("")
+		return
+
+	if(_action == "do_random_name"):
+		runScene("CharacterNameGeneratorScene", [], "name_generator")
 		return
 	
 	if(_action == "do_reset_chatcolor"):
@@ -105,6 +116,11 @@ func _react(_action: String, _args):
 		return
 		
 	setState(_action)
+
+func _react_scene_end(_tag, _result):
+	if(_tag == "name_generator"):
+		if(_result.has("random_name")):
+			GM.main.pickOption("do_pick_name", [_result["random_name"]])
 
 func setSlaveNameTo(newname:String):
 	newname = newname.replace("{", "")

--- a/Scenes/CharacterNameGeneratorScene.gd
+++ b/Scenes/CharacterNameGeneratorScene.gd
@@ -1,0 +1,70 @@
+extends "res://Scenes/SceneBase.gd"
+
+var randomName:String = ""
+var randomNameGender:int = Gender.Other
+
+func _init():
+	sceneID = "CharacterNameGeneratorScene"
+
+func _run():
+	if(state == ""):
+		if(randomName == ""):
+			saynn("Choose which dictionary to use for name generation.")
+		else:
+			saynn("Random name: [color="+getColorStringForGender(randomNameGender)+"]" + randomName + "[/color]")
+
+		addButton("Any", "Generate a random feminine or masculine name", "generate_name_any")
+		addButton("Feminine", "Generate a random feminine name", "generate_name_fem")
+		addButton("Masculine", "Generate a random masculine name", "generate_name_masc")
+
+		if(randomName != ""):
+			addButtonAt(10, "Confirm", "Proceed with selected name", "confirm")
+		else:
+			addDisabledButtonAt(10, "Confirm", "You need to generate a name first")
+		addButtonAt(11, "Cancel", "Enter a name manually", "cancel")
+
+func _react(_action: String, _args):
+	if(_action == "confirm"):
+		endScene({random_name=randomName,random_name_gender=randomNameGender})
+		return
+	if(_action == "cancel"):
+		endScene({})
+		return
+
+	if(_action == "generate_name_any"):
+		randomName = RNG.randomFemaleName() if RNG.chance(50) else RNG.randomMaleName()
+		randomNameGender = Gender.Androgynous
+		return
+	if(_action == "generate_name_fem"):
+		randomName = RNG.randomFemaleName()
+		randomNameGender = Gender.Female
+		return
+	if(_action == "generate_name_masc"):
+		randomName = RNG.randomMaleName()
+		randomNameGender = Gender.Male
+		return
+
+func getColorStringForGender(gender:int):
+	if(gender == Gender.Male):
+		return "#5696EA"
+	if(gender == Gender.Female):
+		return "#FF837A"
+	if(gender == Gender.Androgynous):
+		return "#BA82FF"
+	if(gender == Gender.Other):
+		return "#77D86C"
+	return "#FF0000"
+
+func saveData():
+	var data = .saveData()
+	
+	data["randomName"] = randomName
+	data["randomNameGender"] = randomNameGender
+
+	return data
+	
+func loadData(data):
+	.loadData(data)
+	
+	randomName = SAVE.loadVar(data, "randomName", "")
+	randomNameGender = SAVE.loadVar(data, "randomNameGender", Gender.Other)

--- a/Scenes/Intro/IntroScene.gd
+++ b/Scenes/Intro/IntroScene.gd
@@ -4,9 +4,9 @@ func _init():
 	sceneID = "IntroScene"
 
 func _initScene(_args = []):
-		var uniform = GlobalRegistry.createItem("CasualClothes")
-		
-		GM.pc.getInventory().equipItem(uniform)
+	var uniform = GlobalRegistry.createItem("CasualClothes")
+
+	GM.pc.getInventory().equipItem(uniform)
 
 func _run():
 	if(state == ""):
@@ -51,6 +51,7 @@ func _run():
 		var _ok = textBox.connect("text_entered", self, "onTextBoxEnterPressed")
 		
 		addButton("Confirm", "Choose this name", "setname")
+		addButtonAt(4, "Random?", "Help choose a random name", "randomname")
 		
 
 	if(state == "donecreating"):
@@ -321,15 +322,21 @@ func onTextBoxEnterPressed(_new_text:String):
 
 func _react(_action: String, _args):
 	if(_action == "setname"):
-		if(getTextboxData("player_name") == ""):
-			return
-		
-		GM.pc.setName(getTextboxData("player_name"))
+		if(_args.size() > 0):
+			GM.pc.setName(_args[0])
+		else:
+			if(getTextboxData("player_name") == ""):
+				return
+
+			GM.pc.setName(getTextboxData("player_name"))
 		
 		#setState("pickgender")
 		runScene("CharacterCreatorScene", [], "character_creator")
 		return
-		
+
+	if(_action == "randomname"):
+		runScene("CharacterNameGeneratorScene", [], "name_generator")
+		return
 
 	
 	if(_action == "endthisscene"):
@@ -365,6 +372,9 @@ func _react(_action: String, _args):
 	setState(_action)
 
 func _react_scene_end(_tag, _result):
+	if(_tag == "name_generator"):
+		if(_result.has("random_name")):
+			GM.main.pickOption("setname", [_result["random_name"]])
 	if(_tag == "character_creator"):
 		setFlag("Game_PickedStartingPerks", true)
 		if(!getFlag("PickedSkinAtLeastOnce")):


### PR DESCRIPTION
i've seen too many comments from people being unable to try the game at all, due to the name input text field not working for them, this is sort of an alternate way to get past that input, and a feature for creatures that have difficulties deciding on a name for themselves or for someone else (even if they dont like the random names these might give them an idea for a custom one)

it's in a separate scene so can be reused for naming every single of your born kits or whatever

<img width="732" height="708" alt="an option to choose a random name when asked to enter one" src="https://github.com/user-attachments/assets/6116f0ad-aa4d-4647-b0b6-8f89cc68e0d5" />

<img width="728" height="706" alt="a random name Iris was generated. there is an option to choose between any, feminine or masculine name. then options to confirm or cancel" src="https://github.com/user-attachments/assets/aa3391e2-fdfd-47e0-8371-8a68435d6859" />
