### PR TITLE
split youre and youve for consistency with you/youHe and your/yourHis

### DIFF
--- a/Util/GameParser.gd
+++ b/Util/GameParser.gd
@@ -86,14 +86,24 @@ func callObjectFuncWrapper(_obj: String, _command: String, _args: Array) -> Stri
 		return "[color=red]!RUNTIME ERROR NO CHARACTER FOUND "+_obj+"."+_command+" "+str(_args)+"![/color]"
 	if(_command == "theyre" && _args.size() == 0):
 		return object.theyre()
-	if(_command in ["youre", "youreTheyre"] && _args.size() == 0):
+	if(_command in ["youre"] && _args.size() == 0):
+		if(object.isPlayer()):
+			return "you're"
+		else:
+			return object.getName()+" is"
+	if(_command in ["youreTheyre"] && _args.size() == 0):
 		if(object.isPlayer()):
 			return "you're"
 		else:
 			return object.theyre()
 	if(_command == "theyve" && _args.size() == 0):
 		return object.theyve()
-	if(_command in ["youve", "youveTheyve"] && _args.size() == 0):
+	if(_command in ["youve"] && _args.size() == 0):
+		if(object.isPlayer()):
+			return "you've"
+		else:
+			return object.getName()+" has"
+	if(_command in ["youveTheyve"] && _args.size() == 0):
 		if(object.isPlayer()):
 			return "you've"
 		else:
@@ -235,7 +245,7 @@ func callObjectFuncWrapper(_obj: String, _command: String, _args: Array) -> Stri
 			return object.verbS(str(_args[0]))
 		if(_args.size() == 2):
 			return object.verbS(str(_args[0]), str(_args[1]))
-	if((_command == "yourself") && _args.size() == 0):
+	if((_command in ["yourself", "yourselfHimself", "yourselfThemself"]) && _args.size() == 0):
 		if(object.isPlayer()):
 			return "yourself"
 		return object.himselfHerself()


### PR DESCRIPTION
noticed myself writing snippets like `( "You're" if( sub.isPlayer() ) else "{sub.name} is" )` so i figured i would send an upstream patch for this considering it's inconsistent with how most other parser words translate into text

didn't find any base-game lines that use these. mods might need to switch from `youre` to `youreTheyre`, and from `youve` to `youveTheyve`, depending on the desired output

\-

before

| {char.you}    | {char.youHe}  |
|------------------|---------------------|
| Cinny           | she                   |


| {char.your}  | {char.yourHis}  |
|------------------|-----------------------|
| Cinny's         | her                     |


| {char.youre}  | {char.youreTheyre}  |
|--------------------|------------------------------|
| **she's**      | she's                           |


| {char.youve}  | {char.youveTheyve}  |
|--------------------|------------------------------|
| **she's**      | she's                           |

\-

after

| {char.you}    | {char.youHe}  |
|------------------|---------------------|
| Cinny           | she                   |


| {char.your}  | {char.yourHis}  |
|------------------|-----------------------|
| Cinny's         | her                     |


| {char.youre}  | {char.youreTheyre}  |
|--------------------|------------------------------|
| **Cinny is** | she's                           |


| {char.youve}    | {char.youveTheyve}  |
|----------------------|------------------------------|
| **Cinny has**| she's                           |

\-

also adds `yourselfHimself` and `yourselfThemself` as aliases of `yourself`, since i sometimes write these fully expecting them to exist