### PR TITLE
add ability to fully hide any character from 2+ character anims

### DIFF
--- a/Player/Player3D/Doll3D.gd
+++ b/Player/Player3D/Doll3D.gd
@@ -757,6 +757,7 @@ func applyBodyState(bodystate):
 	var shouldBeHard = bodystate.has("hard") && bodystate["hard"]
 	var shouldBeCaged = bodystate.has("caged") && bodystate["caged"]
 	var shouldBeCondom = bodystate.has("condom") && bodystate["condom"]
+	var shouldBeHiddenCompletely = bodystate.has("hiddenCompletely") && bodystate["hiddenCompletely"]
 	#var shouldLookLeft = bodystate.has("lookLeft") && bodystate["lookLeft"]
 	
 	var exposeBodyparts = []
@@ -797,6 +798,9 @@ func applyBodyState(bodystate):
 	
 	if(shouldForceShowPenis):
 		forceSlotToBeVisible(BodypartSlot.Penis)
+	
+	if(shouldBeHiddenCompletely):
+		visible = false
 	
 	var newChains = []
 	if(bodystate.has("chains")):


### PR DESCRIPTION
StageScene.Sleeping is a two character scene that allows to hide the second character like so:

https://github.com/Alexofp/BDCC/blob/043b540509d57312c6a8c353f5a6d320fade2cf3/Player/StageScene3D/Scenes/Sleeping.gd#L40-L46

there are a lot of 2-3 character animations that I would like to reuse in my mod, and while using

```gdscript
return [StageScene.SexSpitroast, "grope", { pc="some_valid_role", npc="invisible", npc2="invisible" }]
```

gives me the exact silly animation i want without setting the game on fire, it prints out "ERROR: character with the id  wasn't found" which tells me this isn't exactly supported and might break in the future (if it doesn't already break some things that i didn't notice..)

so, short of adding hideNPC to every single animation, i would really appreciate something like this..

```gdscript
return [StageScene.SexSpitroast, "grope", { pc="some_valid_role", npc="some_valid_role", npc2="some_valid_role", npcBodyState={hiddenCompletely=true}, npc2BodyState={hiddenCompletely=true} }]
```

or a similar equivalent