### PR TITLE
add ability to view all mods by author in one click

### DIFF
--- a/UI/ModBrowser/ModBrowser.gd
+++ b/UI/ModBrowser/ModBrowser.gd
@@ -151,7 +151,6 @@ func incrementModCountForAuthors(authorsData) -> void:
 func parseAuthorField(authorField:String) -> Dictionary:
 	var authors:Array = []
 	var preferredSeparator:String = ", "
-	authorField = str(authorField)
 	if(", " in authorField):
 		authors = authorField.split(", ")
 		preferredSeparator = ", "

--- a/UI/ModBrowser/ModBrowser.gd
+++ b/UI/ModBrowser/ModBrowser.gd
@@ -3,15 +3,19 @@ extends Control
 onready var http_request = $HTTPRequest
 onready var http_request_mod = $HTTPRequestMod
 var modEntryScene = preload("res://UI/ModBrowser/ModBrowserEntry.tscn")
+onready var modSearch = $VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/ModSearch
+onready var modListScrollContainer = $VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/ScrollContainer
 onready var modList = $VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/ScrollContainer/ModList
 onready var modDescriptionLabel = $VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer2/VBoxContainer/RichTextLabel
 onready var downloadingContainer = $DownloadingContrainer
 onready var messageDialog = $MessageDialog
 
 var allMods = []
+var modCountByAuthor:Dictionary = {}
 var pickedModEntry:ModEntry
 var visualModEntries = []
 
+var viewModsByAuthorUriPrefix:String = "view_mods_by:"
 var sortType = "newest" #newest, oldest, name
 var downloadedMods = false
 
@@ -31,6 +35,10 @@ func resetMods():
 	pickedModEntry = null
 	Util.delete_children(modList)
 	allMods.clear()
+	modCountByAuthor.clear()
+
+func resetModListScroll() -> void:
+	modListScrollContainer.set_deferred("scroll_vertical", 0)
 
 func updateModList(modsArray = allMods):
 	visualModEntries.clear()
@@ -81,6 +89,7 @@ func _on_HTTPRequest_request_completed(result, _response_code, _headers, body):
 		var newModEntry = ModEntry.new()
 		newModEntry.name = theModEntry["name"]
 		newModEntry.author = theModEntry["author"]
+		newModEntry.authorsData = parseAuthorField(newModEntry.author)
 		newModEntry.description = theModEntry["description"]
 		newModEntry.modversion = theModEntry["modversion"]
 		newModEntry.gameversion = theModEntry["gameversion"]
@@ -88,6 +97,7 @@ func _on_HTTPRequest_request_completed(result, _response_code, _headers, body):
 		newModEntry.index = _i
 		_i += 1
 		
+		incrementModCountForAuthors(newModEntry.authorsData)
 		allMods.append(newModEntry)
 
 	sortType = "newest"
@@ -104,9 +114,10 @@ func updatePickedModEntry():
 	if(pickedModEntry == null):
 		modDescriptionLabel.bbcode_text = "Select a mod on the left"
 	else:
+		var linkedAuthors:Dictionary = getLinkedAuthors(pickedModEntry.authorsData)
 		var text = ""
 		text += "Name: "+str(pickedModEntry.name)+"\n"
-		text += "Author: "+str(pickedModEntry.author)+"\n"
+		text += "Author"+("s" if(linkedAuthors.isMultiple) else "")+": "+linkedAuthors.bbcode+"\n"
 		text += "Mod version: "+str(pickedModEntry.modversion)+"\n"
 		if(!GlobalRegistry.isVersionListHasCompatible(str(pickedModEntry.gameversion))):
 			text += "[color=red]Game version: " + str(pickedModEntry.gameversion)+" (You are running version "+GlobalRegistry.getGameVersionString()+")[/color]\n"
@@ -125,9 +136,47 @@ func updatePickedModEntry():
 func onModEntrySelected(theModEntry):
 	pickedModEntry = theModEntry
 	updatePickedModEntry()
-	
-	
 
+func incrementModCountForAuthors(authorsData) -> void:
+	for authorName in authorsData.authors:
+		var authorNameLower:String = authorName.to_lower()
+		if(modCountByAuthor.has(authorNameLower)):
+			modCountByAuthor[authorNameLower] += 1
+		else:
+			modCountByAuthor[authorNameLower] = 1
+
+func parseAuthorField(authorField:String) -> Dictionary:
+	var authors:Array = []
+	var preferredSeparator:String = ", "
+	authorField = str(authorField)
+	if(", " in authorField):
+		authors = authorField.split(", ")
+		preferredSeparator = ", "
+	elif(" & " in authorField):
+		authors = authorField.split(" & ")
+		preferredSeparator = " & "
+	elif(" / " in authorField):
+		authors = authorField.split(" / ")
+		preferredSeparator = " / "
+	else:
+		authors.append(authorField)
+	return {
+		authors = authors,
+		preferredSeparator = preferredSeparator,
+	}
+
+func getLinkedAuthors(authorsData:Dictionary) -> Dictionary:
+	var bbcode:String = ""
+	for authorName in authorsData.authors:
+		var authorNameLower:String = authorName.to_lower()
+		var authorModCount:int = modCountByAuthor[authorNameLower] if(modCountByAuthor.has(authorNameLower)) else 1
+		if(bbcode != ""):
+			bbcode += authorsData.preferredSeparator
+		bbcode += authorName+" [color=#BBCCFF][url="+viewModsByAuthorUriPrefix+authorName+"]("+str(authorModCount)+" mod"+("s" if(authorModCount >= 2) else "")+")[/url][/color]"
+	return {
+		isMultiple = (authorsData.authors.size() > 1),
+		bbcode = bbcode,
+	}
 
 func _on_DownloadModButton_pressed():
 	if(pickedModEntry == null):
@@ -178,39 +227,66 @@ static func sort_oldest(a, b):
 func _on_SortNameButton_pressed():
 	sortType = "name"
 	allMods.sort_custom(self, "sort_name")
-	updateModList()
+	updateModListWithSearchApplied(modSearch.text)
 
 
 func _on_SortNewestFirstButton_pressed():
 	sortType = "newest"
 	allMods.sort_custom(self, "sort_newest")
-	updateModList()
+	updateModListWithSearchApplied(modSearch.text)
 
 
 func _on_SortOldestFirstButton_pressed():
 	sortType = "oldest"
 	allMods.sort_custom(self, "sort_oldest")
-	updateModList()
+	updateModListWithSearchApplied(modSearch.text)
 
 func _on_CloseButton_pressed():
 	emit_signal("closePressed")
 
 
 func _on_RichTextLabel_meta_clicked(meta):
+	if(meta.begins_with(viewModsByAuthorUriPrefix)):
+		# moves caret to the end as opposed to using modSearch.text = "...
+		modSearch.clear()
+		modSearch.append_at_cursor("\"@"+meta.trim_prefix(viewModsByAuthorUriPrefix)+"\"")
+		updateModListWithSearchApplied(modSearch.text)
+		return
 	var _ok = Util.fixed_shell_open(meta)
 
 
-func _on_ModSearch_text_changed(new_text: String):
+func _on_ModSearch_text_changed(new_text:String) -> void:
+	var new_text_length = new_text.length()
+	if((new_text_length == 0) || (new_text_length > 2)):
+		updateModListWithSearchApplied(new_text)
+
+func updateModListWithSearchApplied(new_text:String) -> void:
 	if new_text.length() > 2:
 		var modsFound = []
+		var new_text_lower:String = new_text.to_lower()
+		var new_text_special:String = ""
+		var isExactAuthorSearch:bool = new_text.begins_with("\"@") && new_text.ends_with("\"")
+		var isSubstringAuthorSearch:bool = new_text.begins_with("@")
+		if(isExactAuthorSearch):
+			new_text_special = new_text.trim_prefix("\"@").trim_suffix("\"")
+		elif(isSubstringAuthorSearch):
+			new_text_special = new_text_lower.trim_prefix("@")
+
 		for mod in allMods:
-			if new_text.begins_with("@"):
-				if mod.author.to_lower().find(new_text.to_lower().trim_prefix("@")) != -1:
+			if(isExactAuthorSearch):
+				for authorName in mod.authorsData.authors:
+					if(new_text_special == authorName):
+						modsFound.append(mod)
+						break
+			elif(isSubstringAuthorSearch):
+				if mod.author.to_lower().find(new_text_special) != -1:
 					modsFound.append(mod)
 			else:
-				if new_text.to_lower() in mod.name.to_lower():
+				if new_text_lower in mod.name.to_lower():
 					modsFound.append(mod)
+		resetModListScroll()
 		updateModList(modsFound)
-	if new_text.length() == 0:
+	else:
+		resetModListScroll()
 		updateModList()
 	

--- a/UI/ModBrowser/ModBrowser.gd
+++ b/UI/ModBrowser/ModBrowser.gd
@@ -10,14 +10,15 @@ onready var modDescriptionLabel = $VBoxContainer/HBoxContainer/VBoxContainer/Pan
 onready var downloadingContainer = $DownloadingContrainer
 onready var messageDialog = $MessageDialog
 
-var allMods = []
+var allMods:Array = []
 var modCountByAuthor:Dictionary = {}
 var pickedModEntry:ModEntry
-var visualModEntries = []
+var visualModEntries:Array = []
 
 var viewModsByAuthorUriPrefix:String = "view_mods_by:"
-var sortType = "newest" #newest, oldest, name
-var downloadedMods = false
+var sortType:String = "newest" #newest, oldest, name
+var searchQuery:String = ""
+var downloadedMods:bool = false
 
 signal closePressed
 
@@ -40,10 +41,11 @@ func resetMods():
 func resetModListScroll() -> void:
 	modListScrollContainer.set_deferred("scroll_vertical", 0)
 
-func updateModList(modsArray = allMods):
+func updateModList():
+	var filteredMods:Array = getSearchQueryFilteredMods()
 	visualModEntries.clear()
 	Util.delete_children(modList)
-	for modEntry in modsArray:
+	for modEntry in filteredMods:
 		var newBrowserEntry = modEntryScene.instance()
 		modList.add_child(newBrowserEntry)
 		newBrowserEntry.setModEntry(modEntry)
@@ -51,6 +53,7 @@ func updateModList(modsArray = allMods):
 		if(modEntry == pickedModEntry):
 			newBrowserEntry.makeActive()
 		visualModEntries.append(newBrowserEntry)
+	resetModListScroll()
 
 func _on_HTTPRequest_request_completed(result, _response_code, _headers, body):
 	if result != HTTPRequest.RESULT_SUCCESS:
@@ -227,19 +230,19 @@ static func sort_oldest(a, b):
 func _on_SortNameButton_pressed():
 	sortType = "name"
 	allMods.sort_custom(self, "sort_name")
-	updateModListWithSearchApplied(modSearch.text)
+	updateModList()
 
 
 func _on_SortNewestFirstButton_pressed():
 	sortType = "newest"
 	allMods.sort_custom(self, "sort_newest")
-	updateModListWithSearchApplied(modSearch.text)
+	updateModList()
 
 
 func _on_SortOldestFirstButton_pressed():
 	sortType = "oldest"
 	allMods.sort_custom(self, "sort_oldest")
-	updateModListWithSearchApplied(modSearch.text)
+	updateModList()
 
 func _on_CloseButton_pressed():
 	emit_signal("closePressed")
@@ -247,10 +250,12 @@ func _on_CloseButton_pressed():
 
 func _on_RichTextLabel_meta_clicked(meta):
 	if(meta.begins_with(viewModsByAuthorUriPrefix)):
+		var exactAuthorSearchQuery:String = "\"@"+meta.trim_prefix(viewModsByAuthorUriPrefix)+"\""
 		# moves caret to the end as opposed to using modSearch.text = "...
 		modSearch.clear()
-		modSearch.append_at_cursor("\"@"+meta.trim_prefix(viewModsByAuthorUriPrefix)+"\"")
-		updateModListWithSearchApplied(modSearch.text)
+		modSearch.append_at_cursor(exactAuthorSearchQuery)
+		setSearchQuery(exactAuthorSearchQuery)
+		updateModList()
 		return
 	var _ok = Util.fixed_shell_open(meta)
 
@@ -258,35 +263,36 @@ func _on_RichTextLabel_meta_clicked(meta):
 func _on_ModSearch_text_changed(new_text:String) -> void:
 	var new_text_length = new_text.length()
 	if((new_text_length == 0) || (new_text_length > 2)):
-		updateModListWithSearchApplied(new_text)
-
-func updateModListWithSearchApplied(new_text:String) -> void:
-	if new_text.length() > 2:
-		var modsFound = []
-		var new_text_lower:String = new_text.to_lower()
-		var new_text_special:String = ""
-		var isExactAuthorSearch:bool = new_text.begins_with("\"@") && new_text.ends_with("\"")
-		var isSubstringAuthorSearch:bool = new_text.begins_with("@")
-		if(isExactAuthorSearch):
-			new_text_special = new_text.trim_prefix("\"@").trim_suffix("\"")
-		elif(isSubstringAuthorSearch):
-			new_text_special = new_text_lower.trim_prefix("@")
-
-		for mod in allMods:
-			if(isExactAuthorSearch):
-				for authorName in mod.authorsData.authors:
-					if(new_text_special == authorName):
-						modsFound.append(mod)
-						break
-			elif(isSubstringAuthorSearch):
-				if mod.author.to_lower().find(new_text_special) != -1:
-					modsFound.append(mod)
-			else:
-				if new_text_lower in mod.name.to_lower():
-					modsFound.append(mod)
-		resetModListScroll()
-		updateModList(modsFound)
-	else:
-		resetModListScroll()
+		setSearchQuery(new_text)
 		updateModList()
+
+func setSearchQuery(newQuery:String) -> void:
+	searchQuery = newQuery
+
+func getSearchQueryFilteredMods() -> Array:
+	if(searchQuery.empty()):
+		return allMods
+	var modsFound:Array = []
+	var searchQueryLower:String = searchQuery.to_lower()
+	var searchQuerySpecial:String = ""
+	var isExactAuthorSearch:bool = searchQuery.begins_with("\"@") && searchQuery.ends_with("\"")
+	var isSubstringAuthorSearch:bool = searchQuery.begins_with("@")
+	if(isExactAuthorSearch):
+		searchQuerySpecial = searchQuery.trim_prefix("\"@").trim_suffix("\"")
+	elif(isSubstringAuthorSearch):
+		searchQuerySpecial = searchQueryLower.trim_prefix("@")
+
+	for mod in allMods:
+		if(isExactAuthorSearch):
+			for authorName in mod.authorsData.authors:
+				if(searchQuerySpecial == authorName):
+					modsFound.append(mod)
+					break
+		elif(isSubstringAuthorSearch):
+			if mod.author.to_lower().find(searchQuerySpecial) != -1:
+				modsFound.append(mod)
+		else:
+			if searchQueryLower in mod.name.to_lower():
+				modsFound.append(mod)
+	return modsFound
 	

--- a/UI/ModBrowser/ModBrowser.tscn
+++ b/UI/ModBrowser/ModBrowser.tscn
@@ -106,21 +106,22 @@ text = "Oldest first"
 [node name="ModSearch" type="LineEdit" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
 margin_top = 52.0
 margin_right = 411.0
-margin_bottom = 76.0
+margin_bottom = 78.0
 max_length = 256
+clear_button_enabled = true
 placeholder_text = "Search Mod..."
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
-margin_top = 80.0
+margin_top = 82.0
 margin_right = 411.0
-margin_bottom = 654.0
+margin_bottom = 646.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource( 2 )
 
 [node name="ModList" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/ScrollContainer"]
 margin_right = 411.0
-margin_bottom = 574.0
+margin_bottom = 564.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -130,6 +131,16 @@ margin_bottom = 31.0
 text = "
 LOADING MOD LIST"
 align = 1
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
+margin_top = 650.0
+margin_right = 411.0
+margin_bottom = 650.0
+
+[node name="HFlowContainer2" type="HFlowContainer" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
+margin_top = 654.0
+margin_right = 411.0
+margin_bottom = 654.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
 margin_left = 429.0

--- a/UI/ModBrowser/ModEntry.gd
+++ b/UI/ModBrowser/ModEntry.gd
@@ -3,6 +3,7 @@ class_name ModEntry
 
 var name:String = "Test mod"
 var author:String = "Someone"
+var authorsData:Dictionary = { authors = "Someone", preferredSeparator = ", " }
 var description:String = ""
 var modversion:String = "1.0"
 var gameversion:String = "*"

--- a/UI/ModBrowser/ModEntry.gd
+++ b/UI/ModBrowser/ModEntry.gd
@@ -3,7 +3,7 @@ class_name ModEntry
 
 var name:String = "Test mod"
 var author:String = "Someone"
-var authorsData:Dictionary = { authors = "Someone", preferredSeparator = ", " }
+var authorsData:Dictionary = { authors = ["Someone"], preferredSeparator = ", " }
 var description:String = ""
 var modversion:String = "1.0"
 var gameversion:String = "*"


### PR DESCRIPTION
the ability to search for `@fox` was already there (much secret, wow), this PR adds `"@keerifox"` for a case-sensitive exact match, and a published mods counter next to each listed mod author, that upon click filters the search to only display mods with that author listed

[2026-08-04_20-10-21.webm](https://github.com/user-attachments/assets/89f3dc32-3038-4f27-a560-43400dc8c028)


other tweaks/fixes:
\- enable X button within the search field to clear contents with one click
\- fix vertical scroll not being moved to the top when the search query changes
\- fix search query not being applied when changing the sort method