### PR TITLE
moddable codeblocks

### DIFF
--- a/Game/Datapacks/UI/CrotchCode/CrotchBlocks.gd
+++ b/Game/Datapacks/UI/CrotchCode/CrotchBlocks.gd
@@ -29,6 +29,14 @@ static func getRightBracket(theType):
 	return ""
 
 static func getAll():
+	var r : Array = getAllDefault()
+	
+	for crotchblock in GlobalRegistry.getCrotchBlocks():
+		r.append(crotchblock)
+	
+	return r
+
+static func getAllDefault():
 	return [
 		"AlwaysTrue",
 		"AlwaysFalse",
@@ -266,7 +274,7 @@ static func createBlock(theID):
 		newBlockScene = GlobalRegistry.codeblocksCache[theID]
 	else:
 		var resourcePath = "res://Game/Datapacks/UI/CrotchCode/CodeBlocks/"+theID+".gd"
-		newBlockScene = load(resourcePath)
+		newBlockScene = GlobalRegistry.getCrotchBlocks()[theID] if GlobalRegistry.getCrotchBlocks().has(theID) else load(resourcePath)
 		if(newBlockScene != null):
 			GlobalRegistry.codeblocksCache[theID] = newBlockScene
 			

--- a/GlobalRegistry.gd
+++ b/GlobalRegistry.gd
@@ -324,6 +324,7 @@ var contentBoardEntries:Dictionary = {}
 var combatAnims:Dictionary = {}
 var combatAnimsApplier := CombatAnimApplier.new()
 var combatAnimLen:Dictionary = {}
+var crotchBlocks : Dictionary = {}
 
 var bodypartStorageNode
 
@@ -1165,6 +1166,22 @@ func getAttacks():
 
 func getPlayerAttackIDs():
 	return playerAttacksIDS
+
+func getCrotchBlocks() -> Dictionary:
+	return crotchBlocks
+
+func registerCrotchBlock(path:String) -> void:
+	if path in CrotchBlocks.getAllDefault():
+		Log.warning("Tried to replace default CrotchBlock, path '%s'" % path)
+		return
+	var resource = load(path)
+	if !resource:
+		Log.printerr("Error registering CrotchBlock at path '%s'" % path)
+		return
+	
+	var fname : String = path.get_file()
+	
+	crotchBlocks[fname.substr(0, fname.find_last("."))] = resource
 
 func registerStatusEffect(path: String):
 	var effect = load(path)


### PR DESCRIPTION
- add ability for mods to add their own codeblocks, but not replace default ones

very simple but makes it easier for mods, i know i wanna make some so :P
i saw that there was a sort of cache for them but figured i'd leave that alone, should be populated with them anyway, although maybe that's not desirable(?)

screenshot of a codeblock from a mod (duplicated the ishybrid one and changed the text)
<img width="267" height="112" alt="image" src="https://github.com/user-attachments/assets/bd5e5e0a-c78b-4243-8399-dfec558d00a2" />
